### PR TITLE
Add Ice Cream results screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import Header from "./components/header";
 import "./styles/styles.css";
 import IceCreamConfig from "./pages/IceCreamConfig"; // adjust if your file is elsewhere
 import IceCreamPlay from "./pages/IceCreamPlay";
+import IceCreamResults from "./pages/IceCreamResults";
 
 
 
@@ -66,6 +67,11 @@ function App() {
 <Route
   path="/icecreamplay"
   element={user && hasInfo ? <IceCreamPlay /> : <Navigate to={user ? "/info" : "/login"} />}
+/>
+
+<Route
+  path="/icecreamresults"
+  element={user && hasInfo ? <IceCreamResults /> : <Navigate to={user ? "/info" : "/login"} />}
 />
 
 </Routes>

--- a/src/pages/IceCreamPlay.js
+++ b/src/pages/IceCreamPlay.js
@@ -1,9 +1,10 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import React, { useState } from "react";
 
 
 export default function IceCreamPlay() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [currentRound, setCurrentRound] = useState(1);
   const [playerChoice, setPlayerChoice] = useState(null);
   const [aiChoice, setAiChoice] = useState(null);
@@ -77,7 +78,13 @@ export default function IceCreamPlay() {
       setAiChoice(null);
       setShowResult(false);
     } else {
-      alert(`Game Over!\nFinal Score:\nYou: $${playerTotal}\nAI: $${aiTotal}`);
+      navigate('/icecreamresults', {
+        state: {
+          playerTotal,
+          aiTotal,
+          rounds,
+        },
+      });
       setPlayerHistory([]);
     }
   }

--- a/src/pages/IceCreamResults.js
+++ b/src/pages/IceCreamResults.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+export default function IceCreamResults() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const { playerTotal = 0, aiTotal = 0, rounds = 0 } = location.state || {};
+
+  const maxCombined = rounds * 600; // Both charge $5 each round
+  const combinedTotal = playerTotal + aiTotal;
+  const percentOfMax = maxCombined ? Math.round((combinedTotal / maxCombined) * 100) : 0;
+
+  return (
+    <div className="icecream-results">
+      <div className="results-box">
+        <h2>🏁 Game Over</h2>
+        <p><strong>Your Profit:</strong> ${playerTotal}</p>
+        <p><strong>AI Profit:</strong> ${aiTotal}</p>
+        <p><strong>Combined Profit:</strong> ${combinedTotal}</p>
+        <p><strong>Max Possible Profit:</strong> ${maxCombined}</p>
+        <p>
+          Together you achieved <strong>{percentOfMax}%</strong> of the maximum
+          possible profit.
+        </p>
+        <button className="results-button" onClick={() => navigate("/icecreamgame")}>Play Again</button>
+        <button className="results-button" onClick={() => navigate("/")}>Home</button>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -237,5 +237,40 @@ input, select {
     color: #666;
     font-weight: bold;
   }
+
+  /* Results page */
+  .icecream-results {
+    display: flex;
+    justify-content: center;
+    margin-top: 40px;
+  }
+
+  .results-box {
+    background: #e0f7fa;
+    padding: 30px;
+    border-radius: 12px;
+    text-align: center;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  }
+
+  .results-box p {
+    font-size: 1.2rem;
+    margin: 10px 0;
+  }
+
+  .results-button {
+    margin: 10px;
+    padding: 10px 20px;
+    font-size: 1rem;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+
+  .results-button:hover {
+    background-color: #0056b3;
+  }
   
   


### PR DESCRIPTION
## Summary
- create `IceCreamResults` page to show final profits and comparison to maximum
- navigate to results page at game end
- add new route for results page in `App.js`
- style results page

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850efbd7bc8832c9b4e42cdf8207491