### PR TITLE
Make site title link home

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -41,7 +41,11 @@ export default function Header() {
   return (
     <nav className="header">
       <div className="header-top">
-        <h1 className="logo">Game Theory Central</h1>
+        <h1 className="logo">
+          <NavLink to="/" className="logo-link">
+            Game Theory Central
+          </NavLink>
+        </h1>
         {isMobile && (
           <button className="menu-toggle" onClick={() => setMenuOpen(!menuOpen)}>
             ☰

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -21,6 +21,12 @@
     font-weight: bold;
 }
 
+/* Make the logo clickable without default link styling */
+.logo-link {
+    text-decoration: none;
+    color: inherit;
+}
+
 /* Navigation links */
 .nav-links {
     list-style: none;


### PR DESCRIPTION
## Summary
- make the header logo text a `NavLink` to `/`
- add CSS class so the logo keeps its styling when clickable

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f841df38832c8c28ac17cae7df76