### PR TITLE
Add setup and instructions to Split the Booty game

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -106,6 +106,14 @@ input, select {
     padding: 40px 20px;
     text-align: center;
   }
+
+  .booty-config {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 20px;
+    text-align: center;
+  }
   
   .intro,
   .round-label {
@@ -267,6 +275,10 @@ input, select {
   }
 
   .icecream-config {
+    padding: 20px 10px;
+  }
+
+  .booty-config {
     padding: 20px 10px;
   }
 }


### PR DESCRIPTION
## Summary
- enhance `Split the Booty` with a setup screen for player name, color, rounds and difficulty
- add instructions screen before gameplay
- adapt AI behavior by difficulty level
- update styles for new setup layout

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685253cb8550832c95d832949cbc026f