### PR TITLE
Add openSection state for header section toggling

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -7,6 +7,7 @@ import { onAuthStateChanged, signOut } from "firebase/auth";
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [user, setUser] = useState(null);
+  const [openSection, setOpenSection] = useState(null);
   const navRef = useRef(null);
   const navigate = useNavigate();
 
@@ -54,7 +55,13 @@ export default function Header() {
             Game Theory Central
           </NavLink>
         </h1>
-        <button className="menu-toggle" onClick={() => setMenuOpen(!menuOpen)}>
+        <button
+          className="menu-toggle"
+          onClick={() => {
+            setMenuOpen(!menuOpen);
+            setOpenSection(null);
+          }}
+        >
           ☰
         </button>
       </div>
@@ -65,7 +72,10 @@ export default function Header() {
             <NavLink
               to="/"
               className={({ isActive }) => (isActive ? "active-link" : "")}
-              onClick={() => setMenuOpen(false)}
+              onClick={() => {
+                setMenuOpen(false);
+                setOpenSection(null);
+              }}
             >
               Home
             </NavLink>


### PR DESCRIPTION
## Summary
- introduce `openSection` state to track which header section is open
- reset `openSection` when toggling menu or navigating

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4bc924188832c88f09aafb91462f7