### PR TITLE
Add Bank dice game

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import IceCreamConfig from "./pages/IceCreamConfig"; // adjust if your file is e
 import IceCreamPlay from "./pages/IceCreamPlay";
 import IceCreamResults from "./pages/IceCreamResults";
 import BootyGame from "./pages/BootyGame";
+import BankGame from "./pages/BankGame";
 
 
 
@@ -78,6 +79,11 @@ function App() {
 <Route
   path="/bootygame"
   element={user && hasInfo ? <BootyGame /> : <Navigate to={user ? "/info" : "/login"} />}
+/>
+
+<Route
+  path="/bankgame"
+  element={user && hasInfo ? <BankGame /> : <Navigate to={user ? "/info" : "/login"} />}
 />
 
 </Routes>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,45 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
-import App from './App';
 
-test('renders learn react link', () => {
+// Mock react-router-dom to avoid dependency on actual implementation
+jest.mock('react-router-dom', () => {
+  const React = require('react');
+  return {
+    BrowserRouter: ({ children }) => <div>{children}</div>,
+    Routes: ({ children }) => <div>{children}</div>,
+    Route: ({ element }) => element,
+    Navigate: () => null,
+    NavLink: ({ children }) => <div>{children}</div>,
+    useNavigate: () => jest.fn(),
+  };
+}, { virtual: true });
+
+// Mock Firebase modules used in App
+jest.mock('./firebase', () => ({
+  auth: {},
+  db: {},
+}));
+
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: (_auth, callback) => {
+    // Immediately invoke callback with no user
+    callback(null);
+    return () => {};
+  },
+  signOut: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+}));
+
+// Import App after mocks are set up
+const App = require('./App').default;
+
+test('renders header logo', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/Game Theory Central/i);
+  expect(headerElement).toBeInTheDocument();
 });
+

--- a/src/pages/BankGame.js
+++ b/src/pages/BankGame.js
@@ -1,0 +1,284 @@
+import React, { useState, useEffect } from "react";
+import "../styles/bank.css";
+
+export default function BankGame() {
+  const [numPlayers, setNumPlayers] = useState(2);
+  const [players, setPlayers] = useState([]);
+  const [phase, setPhase] = useState(0); // 0 setup, 1 first phase, 2 second phase, 3 over
+  const [currentPlayer, setCurrentPlayer] = useState(0);
+  const [pot, setPot] = useState(0);
+  const [dice, setDice] = useState([null, null]);
+  const [message, setMessage] = useState("");
+  const [playerName, setPlayerName] = useState("");
+  const [diceColor, setDiceColor] = useState("red");
+  const [showInstructions, setShowInstructions] = useState(false);
+  const [round, setRound] = useState(1);
+
+  const startGame = () => {
+    const setupPlayers = [
+      {
+        name: playerName || "You",
+        score: 0,
+        banked: false,
+        color: diceColor,
+        isCPU: false,
+      },
+      ...Array.from({ length: numPlayers - 1 }, (_, i) => ({
+        name: `CPU ${i + 1}`,
+        score: 0,
+        banked: false,
+        color: "gray",
+        isCPU: true,
+      })),
+    ];
+    setPlayers(setupPlayers);
+    setPhase(1);
+    setCurrentPlayer(0);
+    setPot(0);
+    setDice([null, null]);
+    setMessage("Phase 1: each player rolls once.");
+    setRound(1);
+  };
+
+  const nextActive = (index, list = players) => {
+    let next = index;
+    do {
+      next = (next + 1) % list.length;
+    } while (list[next].banked);
+    return next;
+  };
+
+  const handleRoll = () => {
+    const d1 = Math.ceil(Math.random() * 6);
+    const d2 = Math.ceil(Math.random() * 6);
+    setDice([d1, d2]);
+
+    if (phase === 1) {
+      const value = d1 + d2 === 7 ? 70 : d1 + d2;
+      setPot((p) => p + value);
+      const msg = `${players[currentPlayer].name} rolled ${d1} + ${d2} for ${value} points.`;
+      setMessage(msg);
+      const next = currentPlayer + 1;
+      if (next >= players.length) {
+        setPhase(2);
+        setCurrentPlayer(0);
+        setMessage("Phase 2: Roll or Bank. 7 ends the round and doubles double the pot.");
+      } else {
+        setCurrentPlayer(next);
+      }
+    } else if (phase === 2) {
+      if (d1 + d2 === 7) {
+        setPot(0);
+        setMessage(`${players[currentPlayer].name} rolled a 7! Pot busts and round ends.`);
+        setPhase(3);
+      } else {
+        let newPot = pot + d1 + d2;
+        let msg = `${players[currentPlayer].name} rolled ${d1} + ${d2} = ${d1 + d2}.`;
+        if (d1 === d2) {
+          newPot *= 2;
+          msg += " Doubles! Pot doubled.";
+        }
+        setPot(newPot);
+        setMessage(msg);
+        const next = nextActive(currentPlayer);
+        setCurrentPlayer(next);
+      }
+    }
+  };
+
+  const handleBank = () => {
+    const updated = [...players];
+    updated[currentPlayer].score += pot;
+    updated[currentPlayer].banked = true;
+    setPlayers(updated);
+    setPot(0);
+    setMessage(`${updated[currentPlayer].name} banked!`);
+
+    if (updated.every((p) => p.banked)) {
+      setPhase(3);
+      return;
+    }
+
+    const next = nextActive(currentPlayer, updated);
+    setCurrentPlayer(next);
+  };
+
+  const nextRound = () => {
+    const reset = players.map((p) => ({ ...p, banked: false }));
+    setPlayers(reset);
+    setPhase(1);
+    setCurrentPlayer(0);
+    setPot(0);
+    setDice([null, null]);
+    setMessage("Phase 1: each player rolls once.");
+    setRound((r) => r + 1);
+  };
+
+  const resetGame = () => {
+    setPhase(0);
+    setPlayers([]);
+    setPot(0);
+    setDice([null, null]);
+    setMessage("");
+    setCurrentPlayer(0);
+    setPlayerName("");
+    setRound(1);
+  };
+
+  useEffect(() => {
+    const current = players[currentPlayer];
+    if (!current || phase === 0 || phase === 3) return;
+    if (current.isCPU) {
+      const timer = setTimeout(() => {
+        if (phase === 1) {
+          handleRoll();
+        } else {
+          if (pot >= 100 || Math.random() < 0.5) {
+            handleBank();
+          } else {
+            handleRoll();
+          }
+        }
+      }, 700);
+      return () => clearTimeout(timer);
+    }
+  }, [currentPlayer, phase]);
+
+  if (showInstructions) {
+    return (
+      <div className="bank-game instructions">
+        <h2>How to Play Bank</h2>
+        <ul>
+          <li>Each round has two phases.</li>
+          <li>Phase 1: Players roll once in order. 7 totals are worth 70 points; no banking.</li>
+          <li>Phase 2: Players may roll or bank. Doubles double the pot. Rolling a 7 ends the round and the pot is lost.</li>
+          <li>Banking locks in the pot for that player but removes them from the round.</li>
+          <li>If a 7 is rolled before you bank, you score 0 for the round.</li>
+        </ul>
+        <button onClick={() => setShowInstructions(false)}>Back</button>
+      </div>
+    );
+  }
+
+  if (phase === 0) {
+    return (
+      <div className="bank-game">
+        <h2>Bank</h2>
+        <label>
+          Name:
+          <input value={playerName} onChange={(e) => setPlayerName(e.target.value)} />
+        </label>
+        <div className="player-select">
+          {Array.from({ length: 6 }, (_, i) => i + 2).map((n) => (
+            <div
+              key={n}
+              className={`player-card ${numPlayers === n ? "selected" : ""}`}
+              onClick={() => setNumPlayers(n)}
+            >
+              {n}
+            </div>
+          ))}
+        </div>
+        <div className="color-select">
+          {["red", "blue", "green", "yellow", "purple", "orange", "black"].map((c) => (
+            <div
+              key={c}
+              className={`color-option ${diceColor === c ? "selected" : ""}`}
+              style={{ backgroundColor: c }}
+              onClick={() => setDiceColor(c)}
+            />
+          ))}
+        </div>
+        <button onClick={startGame}>Start</button>
+        <button onClick={() => setShowInstructions(true)}>Instructions</button>
+      </div>
+    );
+  }
+
+  const leaderboard = [...players].sort((a, b) => b.score - a.score);
+
+  if (phase === 3) {
+    return (
+      <div className="bank-game">
+        <h2>Round Over</h2>
+        <table className="leaderboard">
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th>Total Score</th>
+              <th>Banked</th>
+            </tr>
+          </thead>
+          <tbody>
+            {leaderboard.map((p, i) => (
+              <tr key={i}>
+                <td>{p.name}</td>
+                <td>{p.score}</td>
+                <td>{p.banked ? "Yes" : "No"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <button onClick={nextRound}>Next Round</button>
+        <button onClick={resetGame}>Reset Game</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bank-game">
+      <h2>Bank</h2>
+      <table className="round-info">
+        <thead>
+          <tr>
+            <th>Round</th>
+            <th>Current Pot</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{round}</td>
+            <td>{pot}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Current Player: {players[currentPlayer].name}</p>
+      {dice[0] && (
+        <p className="dice" style={{ color: players[currentPlayer].color }}>
+          {dice[0]} & {dice[1]}
+        </p>
+      )}
+      {message && <p>{message}</p>}
+      {phase === 1 && !players[currentPlayer].isCPU && (
+        <button onClick={handleRoll}>Roll</button>
+      )}
+      {phase === 2 && !players[currentPlayer].isCPU && (
+        <div className="bank-controls">
+          <button onClick={handleRoll}>Roll</button>
+          <button onClick={handleBank} disabled={pot === 0}>
+            Bank
+          </button>
+        </div>
+      )}
+      <table className="leaderboard">
+        <thead>
+          <tr>
+            <th>Player</th>
+            <th>Total Score</th>
+            <th>Banked</th>
+          </tr>
+        </thead>
+        <tbody>
+          {leaderboard.map((p, i) => (
+            <tr key={i}>
+              <td>{p.name}</td>
+              <td>{p.score}</td>
+              <td>{p.banked ? "Yes" : "No"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -41,6 +41,16 @@ export default function Home() {
       color: "#795548"
     },
     {
+      id: "bank",
+      title: "Bank",
+      description: "Roll dice and bank points before a 7 wipes the pot.",
+      route: "/bankgame",
+      status: "live",
+      category: "vs-computer",
+      emoji: "🏦",
+      color: "#2196f3"
+    },
+    {
       id: "logic101",
       title: "Intro to Logical Fallacies",
       description: "Learn how flawed arguments are formed and detected.",

--- a/src/styles/bank.css
+++ b/src/styles/bank.css
@@ -1,0 +1,61 @@
+.bank-game {
+  text-align: center;
+  padding: 20px;
+}
+.bank-controls button {
+  margin: 0 10px;
+}
+.player-select {
+  display: flex;
+  justify-content: center;
+  margin: 10px 0;
+}
+.player-card {
+  width: 40px;
+  height: 40px;
+  border: 1px solid #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 5px;
+  cursor: pointer;
+}
+.player-card.selected {
+  background: #2196f3;
+  color: #fff;
+}
+.color-select {
+  display: flex;
+  justify-content: center;
+  margin: 10px 0;
+}
+.color-option {
+  width: 24px;
+  height: 24px;
+  margin: 0 5px;
+  border: 2px solid transparent;
+  cursor: pointer;
+}
+.color-option.selected {
+  border-color: #000;
+}
+.instructions {
+  max-width: 400px;
+  margin: 0 auto;
+  text-align: left;
+}
+.round-info,
+.leaderboard {
+  margin: 15px auto;
+  border-collapse: collapse;
+}
+.round-info th,
+.round-info td,
+.leaderboard th,
+.leaderboard td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+}
+.dice {
+  font-size: 24px;
+}


### PR DESCRIPTION
## Summary
- allow name, player count, and color selection in Bank game setup
- add CPU opponents with automatic turns and instructions screen
- show round info table and leaderboard with banked status

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b4bed63f44832c9c5e299e768c03a4