### PR TITLE
feat: add multi-round bank game with computer players

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import App from './App';
 
 jest.mock('react-router-dom');
 
-test('renders without crashing', () => {
+test('renders without crashing', async () => {
   const { container } = render(<App />);
-  expect(container.firstChild).toBeTruthy();
+
+  await waitFor(() => {
+    expect(container.firstChild).toBeTruthy();
+  });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock('react-router-dom');
+
+test('renders without crashing', () => {
+  const { container } = render(<App />);
+  expect(container.firstChild).toBeTruthy();
 });

--- a/src/__mocks__/react-router-dom.js
+++ b/src/__mocks__/react-router-dom.js
@@ -1,0 +1,52 @@
+const React = require('react');
+
+const MockAnchor = React.forwardRef(
+  ({ children, className, to, href, ...rest }, ref) => {
+    const computedClassName =
+      typeof className === 'function'
+        ? className({ isActive: false, isPending: false, isTransitioning: false })
+        : className;
+
+    const resolvedHref = typeof to === 'string' ? to : href || '#';
+
+    return React.createElement(
+      'a',
+      {
+        ...rest,
+        ref,
+        href: resolvedHref,
+        className: computedClassName,
+      },
+      children,
+    );
+  },
+);
+
+MockAnchor.displayName = 'MockAnchor';
+
+const BrowserRouter = ({ children }) => React.createElement(React.Fragment, null, children);
+const MemoryRouter = BrowserRouter;
+const Routes = ({ children }) => React.createElement(React.Fragment, null, children);
+const Route = ({ element }) => element ?? null;
+const Navigate = () => null;
+const Outlet = () => null;
+
+const createMockFn = () => (typeof jest !== 'undefined' ? jest.fn() : () => {});
+
+const useNavigate = () => createMockFn();
+const useLocation = () => ({ pathname: '/', search: '', hash: '', state: null, key: 'mock-location' });
+const useParams = () => ({});
+
+module.exports = {
+  BrowserRouter,
+  MemoryRouter,
+  Routes,
+  Route,
+  Navigate,
+  Link: MockAnchor,
+  NavLink: MockAnchor,
+  Outlet,
+  useNavigate,
+  useLocation,
+  useParams,
+};

--- a/src/pages/BankGame.js
+++ b/src/pages/BankGame.js
@@ -1,159 +1,672 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import "../styles/bank.css";
 
+const avatarOptions = [
+  "🐱",
+  "🐶",
+  "🐻",
+  "🦊",
+  "🐼",
+  "🦁",
+  "🐸",
+  "🐰",
+  "🐨",
+  "🐯",
+];
+
+const MIN_PLAYERS = 2;
+const MAX_PLAYERS = 5;
+const MIN_ROUNDS = 1;
+const MAX_ROUNDS = 20;
+
+const strategyLabels = {
+  aggressive: "Aggressive",
+  conservative: "Conservative",
+  middle: "Middle",
+  random: "Random",
+  copycat: "Copycat",
+};
+
+const strategyValues = Object.keys(strategyLabels);
+
+const playerCountOptions = Array.from(
+  { length: MAX_PLAYERS - MIN_PLAYERS + 1 },
+  (_, i) => MIN_PLAYERS + i
+);
+
+const roundCountOptions = Array.from(
+  { length: MAX_ROUNDS - MIN_ROUNDS + 1 },
+  (_, i) => MIN_ROUNDS + i
+);
+
+const computerNamePool = [
+  "Captain Byte",
+  "Lucky Circuit",
+  "Pixel Pirate",
+  "Dice Driver",
+  "Quantum Queen",
+  "Synth Sailer",
+  "Neon Navigator",
+  "Vector Voyager",
+  "Code Corsair",
+  "Crypto Captain",
+  "Gamma Gazer",
+  "Turbo Tactician",
+];
+
+const getRandomItem = (items) => items[Math.floor(Math.random() * items.length)];
+
+const createDefaultPlayerConfig = (index) => ({
+  name: `Player ${index + 1}`,
+  avatar: avatarOptions[index % avatarOptions.length],
+  type: "human",
+  strategy: "",
+});
+
+const generateComputerName = (usedNames, index) => {
+  const available = computerNamePool.filter((name) => !usedNames.has(name));
+  if (available.length) {
+    const candidate = getRandomItem(available);
+    usedNames.add(candidate);
+    return candidate;
+  }
+  const fallback = `CPU ${index + 1}`;
+  usedNames.add(fallback);
+  return fallback;
+};
+
+const decideComputerAction = (player, { pot, lastAction }) => {
+  const rolls = player.roundRolls ?? 0;
+
+  if (pot <= 0) {
+    return "roll";
+  }
+
+  switch (player.strategy) {
+    case "aggressive":
+      if (pot >= 90) {
+        return "bank";
+      }
+      if (rolls >= 3 && pot >= 45) {
+        return Math.random() < 0.4 ? "bank" : "roll";
+      }
+      return "roll";
+    case "conservative":
+      if (pot >= 25 || rolls >= 1) {
+        return "bank";
+      }
+      return "roll";
+    case "middle":
+      if (pot >= 40) {
+        return "bank";
+      }
+      if (rolls >= 2 && pot >= 20) {
+        return "bank";
+      }
+      return "roll";
+    case "copycat":
+      if (!lastAction) {
+        return Math.random() < 0.5 ? "roll" : "bank";
+      }
+      if (lastAction === "bank") {
+        return "bank";
+      }
+      return "roll";
+    case "random":
+    default:
+      return Math.random() < 0.5 ? "roll" : "bank";
+  }
+};
+
+const formatStrategy = (value) => strategyLabels[value] || "";
+
 export default function BankGame() {
-  const [numPlayers, setNumPlayers] = useState(2);
+  const [numPlayers, setNumPlayers] = useState(MIN_PLAYERS);
+  const [totalRounds, setTotalRounds] = useState(5);
+  const [playerConfigs, setPlayerConfigs] = useState(() =>
+    Array.from({ length: MIN_PLAYERS }, (_, i) => createDefaultPlayerConfig(i))
+  );
   const [players, setPlayers] = useState([]);
   const [phase, setPhase] = useState(0); // 0 setup, 1 first phase, 2 second phase, 3 over
   const [currentPlayer, setCurrentPlayer] = useState(0);
   const [pot, setPot] = useState(0);
   const [dice, setDice] = useState([null, null]);
   const [message, setMessage] = useState("");
+  const [currentRound, setCurrentRound] = useState(0);
+  const [lastAction, setLastAction] = useState(null);
 
-  const startGame = () => {
-    const setupPlayers = Array.from({ length: numPlayers }, (_, i) => ({
-      name: `Player ${i + 1}`,
-      score: 0,
-      banked: false,
-    }));
+  useEffect(() => {
+    setPlayerConfigs((prev) =>
+      Array.from({ length: numPlayers }, (_, i) => {
+        const existing = prev[i];
+        if (existing) {
+          return { ...createDefaultPlayerConfig(i), ...existing };
+        }
+        return createDefaultPlayerConfig(i);
+      })
+    );
+  }, [numPlayers]);
+
+  const updatePlayerConfig = (index, field, value) => {
+    setPlayerConfigs((prev) => {
+      const next = [...prev];
+      const base = createDefaultPlayerConfig(index);
+      const current = next[index] ? { ...next[index] } : base;
+      next[index] = { ...base, ...current, [field]: value };
+      return next;
+    });
+  };
+
+  const handleNameChange = (index, value) => {
+    updatePlayerConfig(index, "name", value);
+  };
+
+  const handleAvatarSelect = (index, avatar) => {
+    updatePlayerConfig(index, "avatar", avatar);
+  };
+
+  const handleTypeChange = (index, type) => {
+    setPlayerConfigs((prev) => {
+      const next = [...prev];
+      const base = createDefaultPlayerConfig(index);
+      const current = next[index] ? { ...next[index] } : base;
+      current.type = type;
+      if (type === "human") {
+        current.strategy = "";
+      }
+      next[index] = { ...base, ...current };
+      return next;
+    });
+  };
+
+  const handleStrategyChange = (index, strategy) => {
+    updatePlayerConfig(index, "strategy", strategy);
+  };
+
+  const startGame = useCallback(() => {
+    const assignedNames = new Set();
+    const setupPlayers = playerConfigs.map((config, i) => {
+      const isComputer = config.type === "computer";
+      const trimmedName = config.name.trim();
+      const name =
+        trimmedName || (isComputer ? generateComputerName(assignedNames, i) : `Player ${i + 1}`);
+      const strategy = isComputer
+        ? config.strategy || getRandomItem(strategyValues)
+        : "";
+      return {
+        name,
+        avatar: config.avatar,
+        type: isComputer ? "computer" : "human",
+        strategy,
+        score: 0,
+        banked: false,
+        roundRolls: 0,
+      };
+    });
+
     setPlayers(setupPlayers);
     setPhase(1);
     setCurrentPlayer(0);
     setPot(0);
     setDice([null, null]);
-    setMessage("Phase 1: each player rolls once.");
-  };
+    setCurrentRound(1);
+    setMessage("Round 1: Phase 1 - each player rolls once to build the pot.");
+    setLastAction(null);
+  }, [playerConfigs]);
 
-  const nextActive = (index, list = players) => {
-    let next = index;
-    do {
-      next = (next + 1) % list.length;
-    } while (list[next].banked);
-    return next;
-  };
+  const nextActive = useCallback(
+    (index, list = players) => {
+      if (!list.length) {
+        return 0;
+      }
+      let nextIndex = index;
+      let attempts = 0;
+      do {
+        nextIndex = (nextIndex + 1) % list.length;
+        attempts += 1;
+      } while (list[nextIndex].banked && attempts <= list.length);
+      return nextIndex;
+    },
+    [players]
+  );
 
-  const handleRoll = () => {
+  const handleRoll = useCallback(() => {
+    if (!players.length || phase === 0 || phase === 3) {
+      return;
+    }
+
     const d1 = Math.ceil(Math.random() * 6);
     const d2 = Math.ceil(Math.random() * 6);
+    const total = d1 + d2;
+
     setDice([d1, d2]);
+    setLastAction("roll");
+
+    const roller = players[currentPlayer];
 
     if (phase === 1) {
-      const value = d1 + d2 === 7 ? 70 : d1 + d2;
-      setPot((p) => p + value);
-      const msg = `${players[currentPlayer].name} rolled ${d1} + ${d2} for ${value} points.`;
-      setMessage(msg);
-      const next = currentPlayer + 1;
-      if (next >= players.length) {
+      const value = total === 7 ? 70 : total;
+      const updatedPot = pot + value;
+      const summary = `Round ${currentRound}: ${roller.name} rolled ${d1} + ${d2} for ${value} points. Pot is now ${updatedPot}.`;
+
+      setPot(updatedPot);
+
+      const isLast = currentPlayer + 1 >= players.length;
+      if (isLast) {
         setPhase(2);
         setCurrentPlayer(0);
-        setMessage("Phase 2: Roll or Bank. 7 ends the round and doubles double the pot.");
+        setMessage(
+          `${summary} Phase 2 begins! Roll or bank. A 7 ends the round and rolling doubles doubles the pot.`
+        );
       } else {
-        setCurrentPlayer(next);
+        setCurrentPlayer(currentPlayer + 1);
+        setMessage(summary);
       }
-    } else if (phase === 2) {
-      if (d1 + d2 === 7) {
+      return;
+    }
+
+    if (phase === 2) {
+      setPlayers((prev) =>
+        prev.map((player, index) =>
+          index === currentPlayer
+            ? { ...player, roundRolls: (player.roundRolls ?? 0) + 1 }
+            : player
+        )
+      );
+
+      if (total === 7) {
         setPot(0);
-        setMessage(`${players[currentPlayer].name} rolled a 7! Pot busts and round ends.`);
+        setMessage(`Round ${currentRound}: ${roller.name} rolled a 7! The pot busts and the round ends.`);
         setPhase(3);
       } else {
-        let newPot = pot + d1 + d2;
-        let msg = `${players[currentPlayer].name} rolled ${d1} + ${d2} = ${d1 + d2}.`;
+        let newPot = pot + total;
+        let msg = `Round ${currentRound}: ${roller.name} rolled ${d1} + ${d2} = ${total}.`;
         if (d1 === d2) {
           newPot *= 2;
           msg += " Doubles! Pot doubled.";
         }
+        msg += ` Pot is now ${newPot}.`;
         setPot(newPot);
         setMessage(msg);
-        const next = nextActive(currentPlayer);
-        setCurrentPlayer(next);
+        const nextPlayer = nextActive(currentPlayer);
+        setCurrentPlayer(nextPlayer);
       }
     }
-  };
+  }, [players, phase, pot, currentPlayer, currentRound, nextActive]);
 
-  const handleBank = () => {
-    const updated = [...players];
-    updated[currentPlayer].score += pot;
-    updated[currentPlayer].banked = true;
-    setPlayers(updated);
-    setPot(0);
-    setMessage(`${updated[currentPlayer].name} banked!`);
-
-    if (updated.every((p) => p.banked)) {
-      setPhase(3);
+  const handleBank = useCallback(() => {
+    if (phase !== 2 || pot === 0) {
       return;
     }
 
-    const next = nextActive(currentPlayer, updated);
-    setCurrentPlayer(next);
-  };
+    const potValue = pot;
+    const updatedPlayers = players.map((player, index) =>
+      index === currentPlayer
+        ? { ...player, score: player.score + potValue, banked: true }
+        : player
+    );
+    const banker = updatedPlayers[currentPlayer];
 
-  const resetGame = () => {
+    setPlayers(updatedPlayers);
+    setPot(0);
+    setLastAction("bank");
+    setMessage(`Round ${currentRound}: ${banker.name} banked ${potValue} points!`);
+
+    if (updatedPlayers.every((p) => p.banked)) {
+      setPhase(3);
+    } else {
+      const nextPlayer = nextActive(currentPlayer, updatedPlayers);
+      setCurrentPlayer(nextPlayer);
+    }
+  }, [phase, pot, players, currentPlayer, currentRound, nextActive]);
+
+  const startNextRound = useCallback(() => {
+    if (currentRound >= totalRounds) {
+      return;
+    }
+
+    const nextRound = currentRound + 1;
+    setPlayers((prev) =>
+      prev.map((player) => ({ ...player, banked: false, roundRolls: 0 }))
+    );
+    setPhase(1);
+    setCurrentPlayer(0);
+    setPot(0);
+    setDice([null, null]);
+    setCurrentRound(nextRound);
+    setMessage(
+      `Round ${nextRound}: Phase 1 - each player rolls once to build the pot.`
+    );
+    setLastAction(null);
+  }, [currentRound, totalRounds]);
+
+  const resetGame = useCallback(() => {
     setPhase(0);
     setPlayers([]);
     setPot(0);
     setDice([null, null]);
     setMessage("");
     setCurrentPlayer(0);
-  };
+    setCurrentRound(0);
+    setLastAction(null);
+  }, []);
+
+  useEffect(() => {
+    if (phase === 0 || phase === 3) {
+      return;
+    }
+
+    const active = players[currentPlayer];
+    if (!active || active.type !== "computer" || active.banked) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (phase === 1) {
+        handleRoll();
+      } else if (phase === 2) {
+        const decision = decideComputerAction(active, { pot, lastAction });
+        if (decision === "bank" && pot > 0) {
+          handleBank();
+        } else {
+          handleRoll();
+        }
+      }
+    }, 800);
+
+    return () => clearTimeout(timer);
+  }, [phase, players, currentPlayer, pot, lastAction, handleRoll, handleBank]);
+
+  const describePlayerType = (player) =>
+    player.type === "computer"
+      ? `Computer${player.strategy ? ` · ${formatStrategy(player.strategy)}` : ""}`
+      : "Human";
+
+  const leaderScore = players.length ? Math.max(...players.map((p) => p.score)) : 0;
+  const leaders = leaderScore > 0 ? players.filter((p) => p.score === leaderScore) : [];
+  const scoreboardRows = players
+    .map((player, index) => ({ player, originalIndex: index }))
+    .sort((a, b) => b.player.score - a.player.score);
 
   if (phase === 0) {
     return (
       <div className="bank-game">
         <h2>Bank</h2>
-        <label>
-          Players:
-          <select value={numPlayers} onChange={(e) => setNumPlayers(Number(e.target.value))}>
-            {Array.from({ length: 7 }, (_, i) => i + 2).map((n) => (
-              <option key={n} value={n}>
-                {n}
-              </option>
-            ))}
-          </select>
-        </label>
-        <button onClick={startGame}>Start</button>
+        <div className="bank-setup-panel">
+          <div className="setup-options">
+            <label className="setup-select">
+              Players
+              <select value={numPlayers} onChange={(e) => setNumPlayers(Number(e.target.value))}>
+                {playerCountOptions.map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="setup-select">
+              Rounds
+              <select
+                value={totalRounds}
+                onChange={(e) => setTotalRounds(Number(e.target.value))}
+              >
+                {roundCountOptions.map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="player-setup-grid">
+            {playerConfigs.map((config, index) => {
+              const isComputer = config.type === "computer";
+              return (
+                <div className="player-setup-card" key={index}>
+                  <div className="player-setup-header">
+                    <span className="avatar-preview">{config.avatar}</span>
+                    <span className="player-label">Player {index + 1}</span>
+                  </div>
+                  <label className="player-name-input">
+                    Name
+                    <input
+                      type="text"
+                      value={config.name}
+                      onChange={(e) => handleNameChange(index, e.target.value)}
+                      placeholder={`Player ${index + 1}`}
+                    />
+                  </label>
+                  <label className="player-type-input">
+                    Player Type
+                    <select
+                      value={config.type}
+                      onChange={(e) => handleTypeChange(index, e.target.value)}
+                    >
+                      <option value="human">Human</option>
+                      <option value="computer">Computer</option>
+                    </select>
+                  </label>
+                  {isComputer && (
+                    <label className="player-strategy-input">
+                      Play Style
+                      <select
+                        value={config.strategy}
+                        onChange={(e) => handleStrategyChange(index, e.target.value)}
+                      >
+                        <option value="">Auto Pick</option>
+                        {strategyValues.map((value) => (
+                          <option key={value} value={value}>
+                            {formatStrategy(value)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  <div className="avatar-picker">
+                    {avatarOptions.map((avatar) => (
+                      <button
+                        key={avatar}
+                        type="button"
+                        className={`avatar-option ${config.avatar === avatar ? "selected" : ""}`}
+                        onClick={() => handleAvatarSelect(index, avatar)}
+                      >
+                        {avatar}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <button className="start-button" onClick={startGame}>
+            Start Game
+          </button>
+        </div>
       </div>
     );
   }
 
-  if (phase === 3) {
-    return (
-      <div className="bank-game">
-        <h2>Round Over</h2>
-        <div className="scoreboard">
-          {players.map((p, i) => (
-            <p key={i}>
-              {p.name}: {p.score}
-            </p>
-          ))}
-        </div>
-        <button onClick={resetGame}>Play Again</button>
-      </div>
-    );
-  }
+  const diceAvailable = dice[0] !== null && dice[1] !== null;
+  const activePlayer = players[currentPlayer];
+  const isComputerTurn = phase !== 3 && activePlayer?.type === "computer";
+  const isFinalRound = currentRound === totalRounds;
+
+  const statusMessage =
+    message ||
+    (phase === 1
+      ? `Round ${currentRound}: Phase 1 - each player rolls once to build the pot.`
+      : phase === 2
+      ? `Round ${currentRound}: Phase 2 - Decide to roll or bank. Rolling a 7 ends the round.`
+      : `Round ${currentRound} complete. ${
+          currentRound < totalRounds
+            ? "Start the next round when you're ready."
+            : "Game complete! Review the final leaderboard."
+        }`);
 
   return (
     <div className="bank-game">
       <h2>Bank</h2>
-      <p>Current Player: {players[currentPlayer].name}</p>
-      <p>Pot: {pot}</p>
-      {dice[0] && <p>Dice: {dice[0]} & {dice[1]}</p>}
-      {message && <p>{message}</p>}
-      {phase === 1 && <button onClick={handleRoll}>Roll</button>}
-      {phase === 2 && (
+
+      <div className="bank-status-grid">
+        <div className="info-card">
+          <h3>Round</h3>
+          <div className="round-indicator">
+            <span className="round-current">{currentRound}</span>
+            <span className="round-total">/ {totalRounds}</span>
+          </div>
+        </div>
+
+        <div className="info-card">
+          <h3>{phase === 3 ? "Leaders" : "Current Player"}</h3>
+          {phase === 3 ? (
+            leaders.length ? (
+              <ul className="leader-list">
+                {leaders.map((leader, index) => (
+                  <li key={`${leader.name}-${index}`}>
+                    <span className="player-avatar">{leader.avatar}</span>
+                    <div className="leader-details">
+                      <span className="player-name">{leader.name}</span>
+                      {leader.type === "computer" && (
+                        <span className="player-tag">
+                          Computer · {formatStrategy(leader.strategy)}
+                        </span>
+                      )}
+                    </div>
+                    <span className="leader-score">{leader.score}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="info-placeholder">No points banked yet.</p>
+            )
+          ) : activePlayer ? (
+            <div className="player-callout">
+              <span className="player-avatar">{activePlayer.avatar}</span>
+              <div className="player-identifiers">
+                <span className="player-name">{activePlayer.name}</span>
+                {activePlayer.type === "computer" && (
+                  <span className="player-tag">
+                    Computer · {formatStrategy(activePlayer.strategy)}
+                  </span>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className="info-placeholder">Preparing players...</p>
+          )}
+        </div>
+
+        <div className="info-card">
+          <h3>Round Total</h3>
+          <p className="info-value">{pot}</p>
+        </div>
+
+        <div className="info-card">
+          <h3>Last Roll</h3>
+          {diceAvailable ? (
+            <div className="dice-display">
+              <span className="die">{dice[0]}</span>
+              <span className="dice-symbol">+</span>
+              <span className="die">{dice[1]}</span>
+              <span className="dice-symbol">=</span>
+              <span className="dice-total">{dice[0] + dice[1]}</span>
+            </div>
+          ) : (
+            <p className="info-placeholder">No rolls yet.</p>
+          )}
+        </div>
+
+        <div className="info-card message-card">
+          <h3>Status</h3>
+          <p className="message-text">{statusMessage}</p>
+        </div>
+      </div>
+
+      {phase !== 3 ? (
         <div className="bank-controls">
-          <button onClick={handleRoll}>Roll</button>
-          <button onClick={handleBank} disabled={pot === 0}>
-            Bank
+          <button className="primary" onClick={handleRoll} disabled={isComputerTurn}>
+            Roll Dice
+          </button>
+          {phase === 2 && (
+            <button onClick={handleBank} disabled={pot === 0 || isComputerTurn}>
+              Bank Points
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="round-summary">
+          <h3>{isFinalRound ? "Game Complete" : `Round ${currentRound} Complete`}</h3>
+          {leaders.length ? (
+            <p>
+              {leaders.map((leader) => leader.name).join(", ")}{" "}
+              {leaders.length > 1
+                ? isFinalRound
+                  ? "tie for the win"
+                  : "share the lead"
+                : isFinalRound
+                ? "wins the game"
+                : "leads"}{" "}
+              with {leaderScore} points.
+            </p>
+          ) : (
+            <p>No one has scored yet. Keep rolling!</p>
+          )}
+        </div>
+      )}
+
+      <div className="scoreboard-section">
+        <h3>Scoreboard</h3>
+        <table className="score-table">
+          <thead>
+            <tr>
+              <th>Avatar</th>
+              <th>Player</th>
+              <th>Type</th>
+              <th>Score</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {scoreboardRows.map(({ player, originalIndex }) => (
+              <tr
+                key={originalIndex}
+                className={`${
+                  leaderScore > 0 && player.score === leaderScore ? "leader" : ""
+                } ${phase !== 3 && originalIndex === currentPlayer ? "active" : ""}`.trim()}
+              >
+                <td className="avatar-cell">{player.avatar}</td>
+                <td>{player.name}</td>
+                <td className="type-cell">{describePlayerType(player)}</td>
+                <td>{player.score}</td>
+                <td>
+                  {phase === 3
+                    ? player.score === leaderScore && leaderScore > 0
+                      ? "Winner"
+                      : ""
+                    : player.banked
+                    ? "Banked"
+                    : "Rolling"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {phase === 3 && (
+        <div className="bank-footer-controls">
+          {currentRound < totalRounds && (
+            <button className="primary" onClick={startNextRound}>
+              Next Round
+            </button>
+          )}
+          <button onClick={resetGame}>
+            {currentRound < totalRounds ? "Restart" : "Play Again"}
           </button>
         </div>
       )}
-      <div className="scoreboard">
-        {players.map((p, i) => (
-          <p key={i}>
-            {p.name}: {p.score} {p.banked && phase !== 3 ? "\u2705" : ""}
-          </p>
-        ))}
-      </div>
     </div>
   );
 }

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -112,7 +112,7 @@ export default function Home() {
               >
                 <h3>{game.title}</h3>
                 <p>{game.description}</p>
-                </motion.div>
+              </motion.div>
             ))}
         </div>
       </div>
@@ -120,27 +120,9 @@ export default function Home() {
       {/* Challenge the Computer */}
       <div id="multiplayer" className="section vs-computer">
         <h2>🤖 Multiplayer Games</h2>
-        {games
-          .filter((g) => g.id === "Booty" && g.status === "live")
-          .map((game) => (
-            <motion.div
-              key={game.id}
-              className="game-card stacked"
-              onClick={() => navigate(game.route)}
-              style={{ borderLeft: `6px solid ${game.color}` }}
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.97 }}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.1, ease: "easeOut" }}
-            >
-              <h3>{game.title}</h3>
-              <p>{game.description}</p>
-              </motion.div>
-          ))}
-        <div className="game-grid">
+        <div className="game-grid vs-grid">
           {games
-            .filter((g) => g.category === "vs-computer" && g.status === "live" && g.id !== "Booty")
+            .filter((g) => g.category === "vs-computer" && g.status === "live")
             .map((game) => (
               <motion.div
                 key={game.id}
@@ -155,7 +137,7 @@ export default function Home() {
               >
                 <h3>{game.title}</h3>
                 <p>{game.description}</p>
-                </motion.div>
+              </motion.div>
             ))}
         </div>
       </div>
@@ -180,7 +162,7 @@ export default function Home() {
               >
                 <h3>{game.title}</h3>
                 <p>{game.description}</p>
-                </motion.div>
+              </motion.div>
             ))}
         </div>
       </div>
@@ -205,7 +187,7 @@ export default function Home() {
               >
                 <h3>{game.title}</h3>
                 <p>{game.description}</p>
-                </motion.div>
+              </motion.div>
             ))}
         </div>
       </div>

--- a/src/styles/bank.css
+++ b/src/styles/bank.css
@@ -1,10 +1,575 @@
 .bank-game {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 40px 20px 80px;
+  font-family: "Segoe UI", sans-serif;
+  color: #1f2d3d;
+}
+
+.bank-game h2 {
   text-align: center;
-  padding: 20px;
+  font-size: 2.5rem;
+  margin-bottom: 30px;
+  color: #1f3a8a;
 }
+
+.bank-setup-panel {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 28px;
+  box-shadow: 0 18px 45px rgba(31, 58, 138, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.setup-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.setup-select {
+  font-weight: 600;
+  color: #1f3a8a;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  flex: 1 1 140px;
+}
+
+.setup-select select {
+  width: 100%;
+  min-width: 140px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid #cad5ff;
+  background: #f5f8ff;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f3a8a;
+  cursor: pointer;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.setup-select select:focus {
+  outline: none;
+  border-color: #6f7fff;
+  box-shadow: 0 0 0 3px rgba(111, 127, 255, 0.25);
+}
+
+.player-setup-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.player-setup-card {
+  background: linear-gradient(135deg, #f5f8ff 0%, #eef2ff 100%);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: inset 0 0 0 1px rgba(31, 58, 138, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.player-setup-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  color: #1f3a8a;
+  font-size: 1.05rem;
+}
+
+.avatar-preview {
+  font-size: 2rem;
+}
+
+.player-name-input {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: #1f2d3d;
+}
+
+.player-name-input input {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #cad5ff;
+  background: #ffffff;
+  font-size: 0.95rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.player-name-input input:focus {
+  outline: none;
+  border-color: #6f7fff;
+  box-shadow: 0 0 0 3px rgba(111, 127, 255, 0.25);
+}
+
+.player-type-input,
+.player-strategy-input {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: #1f2d3d;
+}
+
+.player-type-input select,
+.player-strategy-input select {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #cad5ff;
+  background: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1f3a8a;
+  cursor: pointer;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.player-type-input select:focus,
+.player-strategy-input select:focus {
+  outline: none;
+  border-color: #6f7fff;
+  box-shadow: 0 0 0 3px rgba(111, 127, 255, 0.25);
+}
+
+.avatar-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  gap: 8px;
+}
+
+.avatar-option {
+  border: 1px solid #d0d8ff;
+  background: #ffffff;
+  border-radius: 10px;
+  font-size: 1.5rem;
+  padding: 6px 0;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.avatar-option:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(31, 58, 138, 0.18);
+}
+
+.avatar-option.selected {
+  background: linear-gradient(135deg, #4f6eff, #7b8bff);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(79, 110, 255, 0.35);
+}
+
+.start-button {
+  align-self: center;
+  padding: 12px 28px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #4f6eff, #1f3a8a);
+  color: #ffffff;
+  font-size: 1.05rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 14px 30px rgba(31, 58, 138, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.start-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(31, 58, 138, 0.35);
+}
+
+.start-button:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 20px rgba(31, 58, 138, 0.25);
+}
+
+.bank-status-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 28px;
+}
+
+.info-card {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 20px 22px;
+  box-shadow: 0 20px 45px rgba(31, 58, 138, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 150px;
+}
+
+.info-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6b7a99;
+}
+
+.round-indicator {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.round-current {
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: #1f3a8a;
+}
+
+.round-total {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #6b7a99;
+}
+
+.info-value {
+  margin: 0;
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: #1f3a8a;
+}
+
+.player-callout {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1f2d3d;
+}
+
+.player-identifiers {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.player-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.player-avatar {
+  font-size: 2.4rem;
+}
+
+.player-tag {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6f7fff;
+  font-weight: 700;
+}
+
+.leader-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.leader-list li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  color: #1f2d3d;
+}
+
+.leader-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.leader-score {
+  margin-left: auto;
+  background: #eef3ff;
+  color: #1f3a8a;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.info-placeholder {
+  margin: 0;
+  color: #8a95b5;
+  font-style: italic;
+}
+
+.dice-display {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-weight: 700;
+}
+
+.die,
+.dice-total {
+  width: 54px;
+  height: 54px;
+  border-radius: 14px;
+  background: #f0f4ff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: #1f3a8a;
+  box-shadow: inset 0 0 0 1px rgba(31, 58, 138, 0.12);
+}
+
+.dice-total {
+  background: #dfe6ff;
+}
+
+.dice-symbol {
+  font-size: 1.4rem;
+  color: #8a95b5;
+  font-weight: 600;
+}
+
+.message-card {
+  grid-column: 1 / -1;
+}
+
+.message-text {
+  margin: 0;
+  line-height: 1.5;
+  color: #33415c;
+}
+
+.bank-controls {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 28px;
+  flex-wrap: wrap;
+}
+
 .bank-controls button {
-  margin: 0 10px;
+  padding: 12px 26px;
+  border-radius: 999px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
-.scoreboard {
+
+.bank-controls button.primary {
+  background: linear-gradient(135deg, #4f6eff, #1f3a8a);
+  color: #ffffff;
+  box-shadow: 0 12px 30px rgba(31, 58, 138, 0.28);
+}
+
+.bank-controls button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(31, 58, 138, 0.32);
+}
+
+.bank-controls button.primary:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 20px rgba(31, 58, 138, 0.26);
+}
+
+.bank-controls button:not(.primary) {
+  background: #ffffff;
+  color: #1f3a8a;
+  border: 1px solid #ccd4ff;
+  box-shadow: 0 10px 24px rgba(31, 58, 138, 0.12);
+}
+
+.bank-controls button:not(.primary):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(31, 58, 138, 0.18);
+}
+
+.bank-controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.round-summary {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 20px 24px;
+  box-shadow: 0 18px 40px rgba(31, 58, 138, 0.16);
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.round-summary h3 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+  color: #1f3a8a;
+}
+
+.round-summary p {
+  margin: 0;
+  color: #33415c;
+  font-weight: 600;
+}
+
+.scoreboard-section {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 22px;
+  box-shadow: 0 20px 45px rgba(31, 58, 138, 0.18);
   margin-top: 20px;
+  overflow-x: auto;
+}
+
+.scoreboard-section h3 {
+  margin-top: 0;
+  color: #1f3a8a;
+  font-size: 1.2rem;
+}
+
+.score-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.score-table thead th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  color: #6b7a99;
+  padding: 12px 14px;
+}
+
+.score-table tbody td {
+  padding: 14px;
+  border-top: 1px solid #e0e5ff;
+  font-size: 0.95rem;
+  color: #33415c;
+}
+
+.score-table tbody tr:nth-child(even) td {
+  background: #f7f9ff;
+}
+
+.score-table tbody tr.leader td {
+  background: linear-gradient(135deg, rgba(79, 110, 255, 0.15), rgba(31, 58, 138, 0.1));
+  font-weight: 700;
+}
+
+.score-table tbody tr.active td {
+  box-shadow: inset 0 0 0 2px rgba(79, 110, 255, 0.35);
+}
+
+.score-table tbody tr td:last-child {
+  font-weight: 600;
+}
+
+.avatar-cell {
+  text-align: center;
+  font-size: 1.6rem;
+}
+
+.type-cell {
+  font-size: 0.85rem;
+  color: #6b7a99;
+  font-weight: 600;
+}
+
+.bank-footer-controls {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.bank-footer-controls button {
+  padding: 12px 28px;
+  border-radius: 999px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.bank-footer-controls button.primary {
+  background: linear-gradient(135deg, #1f3a8a, #4f6eff);
+  color: #ffffff;
+  box-shadow: 0 16px 32px rgba(31, 58, 138, 0.28);
+}
+
+.bank-footer-controls button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(31, 58, 138, 0.32);
+}
+
+.bank-footer-controls button.primary:active {
+  transform: translateY(0);
+  box-shadow: 0 10px 22px rgba(31, 58, 138, 0.24);
+}
+
+.bank-footer-controls button:not(.primary) {
+  background: #ffffff;
+  color: #1f3a8a;
+  border: 1px solid #ccd4ff;
+  box-shadow: 0 12px 28px rgba(31, 58, 138, 0.18);
+}
+
+.bank-footer-controls button:not(.primary):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(31, 58, 138, 0.22);
+}
+
+.bank-footer-controls button:not(.primary):active {
+  transform: translateY(0);
+  box-shadow: 0 8px 18px rgba(31, 58, 138, 0.16);
+}
+
+@media (max-width: 600px) {
+  .bank-game {
+    padding: 30px 16px 60px;
+  }
+
+  .bank-game h2 {
+    font-size: 2.1rem;
+  }
+
+  .setup-select select {
+    width: 100%;
+  }
+
+  .info-card {
+    min-height: 140px;
+  }
+
+  .dice-display {
+    flex-wrap: wrap;
+  }
+
+  .die,
+  .dice-total {
+    width: 48px;
+    height: 48px;
+  }
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -94,6 +94,7 @@
       font-size: 0.85rem;
     }
   }
+
 /* SECTION COLOR THEMES */
 .section.solo h2 {
     color: #ff5e5e;
@@ -132,8 +133,17 @@
     margin-bottom: 10px;
   }
 
-  /* Stacked card below section header */
-  .game-card.stacked {
-    margin: 0 10px 30px;
+  .game-grid.vs-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    padding: 0 10px;
+    max-width: 720px;
+    margin: 0 auto;
   }
+
+  .game-grid.vs-grid .game-card {
+    width: 100%;
+  }
+
   


### PR DESCRIPTION
## Summary
- add multi-round configuration, player type controls, and computer strategy automation to the Bank game flow
- surface round progress, AI details, and expanded scoreboard information during play and post-round summaries
- refresh Bank game styling for the new setup inputs, round indicator, and footer controls

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b4c6b1d31c832cb65cc69c2b252db8