### PR TITLE
Fix BankGame turn advancement bug

### DIFF
--- a/src/pages/BankGame.js
+++ b/src/pages/BankGame.js
@@ -265,8 +265,8 @@ export default function BankGame() {
           `${summary} Phase 2 begins! Roll or bank. A 7 ends the round and rolling doubles doubles the pot.`
         );
       } else {
-        setCurrentPlayer(next);
-        setCurrentPlayer(currentPlayer + 1);
+        const nextPlayer = (currentPlayer + 1) % players.length;
+        setCurrentPlayer(nextPlayer);
         setMessage(summary);
       }
       return;


### PR DESCRIPTION
## Summary
- fix the undefined reference in the BankGame phase-one turn handoff logic
- compute the next player index explicitly so the game advances correctly

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e48e2ce738832c91a9aa22faea4054