### PR TITLE
Revamp home page with marketing layout

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1,196 +1,401 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
 import { auth } from "../firebase";
 import "../styles/home.css";
-import { motion } from "framer-motion";
 
+const TRAITS = [
+  { id: "exploration", label: "Exploration", blurb: "Try new ideas and chase curiosity." },
+  { id: "logic", label: "Logic & Reasoning", blurb: "Build conclusions that fit the facts." },
+  { id: "adaptability", label: "Adaptability", blurb: "Change your strategy when rules change." },
+  { id: "risk", label: "Risk & Reward", blurb: "Make smarter decisions under pressure." },
+  { id: "cooperation", label: "Cooperation", blurb: "Use trust and strategy for win–wins." },
+  { id: "metacognition", label: "Metacognition", blurb: "See how your mind works—then improve it." },
+  { id: "creativity", label: "Creativity", blurb: "Turn imagination into solutions." }
+];
+
+const GAMES = [
+  {
+    id: "pattern",
+    name: "Pattern Game",
+    tagline: "Test before you guess.",
+    traits: ["exploration", "logic", "metacognition"],
+    route: "/game"
+  },
+  {
+    id: "ice-cream",
+    name: "Ice Cream Battle",
+    tagline: "Trust, betray, or outplay.",
+    traits: ["cooperation", "risk", "metacognition"],
+    route: "/icecreamgame"
+  },
+  {
+    id: "booty",
+    name: "Split the Booty",
+    tagline: "Plan, adapt, and outthink.",
+    traits: ["logic", "adaptability", "creativity"],
+    route: "/bootygame"
+  }
+];
 
 export default function Home() {
   const navigate = useNavigate();
+  const howRef = useRef(null);
   const [user, setUser] = useState(null);
-
-  const games = [
-    {
-      id: "pattern",
-      title: "Pattern Guessing Game",
-      description: "Test your logic with sequences and uncover hidden rules.",
-      route: "/game",
-      status: "live",
-      category: "solo",
-      emoji: "🧩",
-      color: "#ff5e5e"
-    },
-    {
-      id: "IceCream",
-      title: "Ice Cream Battle",
-      description: "Maximize your profits while working against your opponent.",
-      route: "/icecreamgame",
-      status: "live",
-      category: "vs-computer",
-      emoji: "🍦",
-      color: "#ff9800"
-    },
-    {
-      id: "Booty",
-      title: "Split the Booty",
-      description: "Divide the loot fairly or risk getting nothing.",
-      route: "/bootygame",
-      status: "live",
-      category: "vs-computer",
-      emoji: "🏴\u200d☠️",
-      color: "#795548"
-    },
-    {
-      id: "bank",
-      title: "Bank",
-      description: "Roll dice and bank points before a 7 wipes the pot.",
-      route: "/bankgame",
-      status: "live",
-      category: "vs-computer",
-      emoji: "🏦",
-      color: "#2196f3"
-    },
-    {
-      id: "logic101",
-      title: "Intro to Logical Fallacies",
-      description: "Learn how flawed arguments are formed and detected.",
-      route: "/learn/fallacies",
-      status: "live",
-      category: "education",
-      emoji: "📚",
-      color: "#4caf50"
-    },
-    {
-      id: "analysis",
-      title: "Thinking Insights",
-      description: "Explore aggregated thinking trends across all games.",
-      route: "/analysis",
-      status: "live",
-      category: "data",
-      emoji: "📊",
-      color: "#673ab7"
-    }
-  ];
-  
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((u) => setUser(u));
     return () => unsubscribe();
   }, []);
 
+  const scrollToHow = () => {
+    if (howRef.current) {
+      howRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
+
+  const handlePlayNow = () => navigate("/game");
+
   return (
-    <div className="home-container">
-      <div className="home-header">
-        <h1>🧠 Critical Thinking Hub</h1>
-        {user && (
-          <p className="welcome">
-            Welcome, {user.displayName || "Thinker"}!
+    <main className="home-landing">
+      <Hero
+        onHowClick={scrollToHow}
+        onPlayClick={handlePlayNow}
+        userName={user?.displayName || (user ? "Thinker" : null)}
+      />
+      <div ref={howRef}>
+        <HowItWorks />
+      </div>
+      <SevenTraits onStartTest={handlePlayNow} />
+      <GamesShowcase onPlay={(route) => navigate(route)} />
+      <GrowthSection onStartJourney={handlePlayNow} onViewDashboard={() => navigate("/analysis")} />
+      <WhyItMatters onLearnScience={() => navigate("/learn/fallacies")} />
+      <ClosingCta onPlayNow={handlePlayNow} onLearnMore={() => navigate("/analysis")} />
+    </main>
+  );
+}
+
+function PrimaryButton({
+  children,
+  onClick,
+  ariaLabel
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className="primary-button"
+    >
+      {children}
+    </button>
+  );
+}
+
+function SecondaryButton({
+  children,
+  onClick,
+  ariaLabel
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className="secondary-button"
+    >
+      {children}
+    </button>
+  );
+}
+
+function TraitPill({ label, active = false }) {
+  return <span className={`trait-pill${active ? " trait-pill--active" : ""}`}>{label}</span>;
+}
+
+function Hero({ onHowClick, onPlayClick, userName }) {
+  return (
+    <section className="hero">
+      <div className="hero__background" aria-hidden="true" />
+      <div className="section-inner hero__content">
+        <header className="hero__header">
+          <div className="hero__badge">Cognify</div>
+          <h1 className="hero__title">Play Smarter. Think Deeper.</h1>
+          <p className="hero__subtitle">
+            Challenge your mind with games that reveal how you think. Measure your skills. Train your brain. Watch yourself
+            grow.
           </p>
-        )}
-        <p className="subtext">
-          Choose a section below to play games, sharpen your mind, and explore data.
+          {userName && <p className="hero__welcome">Welcome back, {userName}.</p>}
+          <div className="hero__actions">
+            <PrimaryButton ariaLabel="Play Now" onClick={onPlayClick}>
+              Play Now
+            </PrimaryButton>
+            <SecondaryButton ariaLabel="How It Works" onClick={onHowClick}>
+              How It Works
+            </SecondaryButton>
+          </div>
+        </header>
+        <div className="hero__traits">
+          {TRAITS.slice(0, 5).map((t) => (
+            <TraitPill key={t.id} label={t.label} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function HowItWorks() {
+  const steps = [
+    { title: "Play", desc: "Fun, fast challenges built on real cognitive science.", icon: "🎮" },
+    { title: "Discover", desc: "See your Thinking Profile grow across seven skills.", icon: "🧭" },
+    { title: "Improve", desc: "Get tailored missions to strengthen how you think.", icon: "⚡" }
+  ];
+  return (
+    <section className="how" aria-labelledby="how-heading">
+      <div className="section-inner">
+        <h2 id="how-heading" className="section-title">
+          How It Works
+        </h2>
+        <p className="section-subtitle">Play quick games, discover your strengths, and follow missions to grow.</p>
+        <div className="how__grid">
+          {steps.map((s) => (
+            <div key={s.title} className="how__card">
+              <div className="how__icon" aria-hidden="true">
+                {s.icon}
+              </div>
+              <h3 className="how__title">{s.title}</h3>
+              <p className="how__description">{s.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function RadarSvg({ values }) {
+  const R = 80;
+  const cx = 100;
+  const cy = 100;
+  const points = values.map((v, i) => {
+    const angle = (Math.PI * 2 * i) / values.length - Math.PI / 2;
+    const r = R * (0.2 + 0.8 * v);
+    const x = cx + r * Math.cos(angle);
+    const y = cy + r * Math.sin(angle);
+    return `${x},${y}`;
+  });
+  return (
+    <svg width="200" height="200" role="img" aria-label="Thinking Profile Radar" className="radar">
+      {[0.4, 0.6, 0.8, 1].map((g, i) => (
+        <circle key={i} cx={cx} cy={cy} r={R * g} fill="none" stroke="#e2e8f0" strokeDasharray="4 4" />
+      ))}
+      {new Array(values.length).fill(0).map((_, i) => {
+        const angle = (Math.PI * 2 * i) / values.length - Math.PI / 2;
+        const x2 = cx + R * Math.cos(angle);
+        const y2 = cy + R * Math.sin(angle);
+        return <line key={i} x1={cx} y1={cy} x2={x2} y2={y2} stroke="#e2e8f0" />;
+      })}
+      <polygon points={points.join(" ")} fill="#6366F170" stroke="#6366F1" strokeWidth="2" />
+    </svg>
+  );
+}
+
+function SevenTraits({ onStartTest }) {
+  const [active, setActive] = useState(TRAITS[0].id);
+  const activeTrait = useMemo(() => TRAITS.find((t) => t.id === active), [active]);
+  const mockValues = [0.65, 0.55, 0.48, 0.6, 0.42, 0.58, 0.45];
+
+  if (!activeTrait) {
+    return null;
+  }
+
+  return (
+    <section className="traits" aria-labelledby="traits-heading">
+      <div className="section-inner">
+        <h2 id="traits-heading" className="section-title">
+          The Seven Traits
+        </h2>
+        <p className="section-subtitle">Seven skills that make thinking clear, creative, and adaptable.</p>
+
+        <div className="traits__grid">
+          <div className="traits__radar">
+            <RadarSvg values={mockValues} />
+          </div>
+
+          <div className="traits__content">
+            <ul className="traits__tabs">
+              {TRAITS.map((t) => (
+                <li key={t.id}>
+                  <button
+                    className={`traits__tab${active === t.id ? " traits__tab--active" : ""}`}
+                    onClick={() => setActive(t.id)}
+                    aria-label={`Select ${t.label}`}
+                    type="button"
+                  >
+                    {t.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+
+            <div className="traits__card">
+              <h3 className="traits__card-title">{activeTrait.label}</h3>
+              <p className="traits__card-text">{activeTrait.blurb}</p>
+              <div className="traits__card-actions">
+                <PrimaryButton ariaLabel="Take 3-minute test" onClick={onStartTest}>
+                  Take the 3-Minute Thinking Test
+                </PrimaryButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function GamesShowcase({ onPlay }) {
+  return (
+    <section className="games" aria-labelledby="games-heading">
+      <div className="section-inner">
+        <h2 id="games-heading" className="section-title">
+          Inside the Games
+        </h2>
+        <p className="section-subtitle">Play fast, learn fast. Each game targets different thinking skills.</p>
+
+        <div className="games__grid">
+          {GAMES.map((g) => (
+            <article key={g.id} className="games__card">
+              <div className="games__visual" aria-hidden="true">
+                <span className="games__visual-text">Gameplay Preview</span>
+              </div>
+              <h3 className="games__card-title">{g.name}</h3>
+              <p className="games__card-text">{g.tagline}</p>
+              <div className="games__traits">
+                {g.traits.map((tId) => {
+                  const t = TRAITS.find((x) => x.id === tId);
+                  return t ? <TraitPill key={tId} label={t.label} /> : null;
+                })}
+              </div>
+              <div className="games__actions">
+                <SecondaryButton ariaLabel={`Play ${g.name}`} onClick={() => onPlay(g.route)}>
+                  Play Now
+                </SecondaryButton>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function GrowthSection({ onStartJourney, onViewDashboard }) {
+  const bars = [
+    { id: "exploration", label: "Exploration", value: 62 },
+    { id: "logic", label: "Logic", value: 55 },
+    { id: "adaptability", label: "Adaptability", value: 48 },
+    { id: "risk", label: "Risk & Reward", value: 60 },
+    { id: "metacognition", label: "Metacognition", value: 58 }
+  ];
+  return (
+    <section className="growth">
+      <div className="section-inner growth__grid">
+        <div className="growth__card">
+          <h3 className="growth__card-title">Your Thinking Profile</h3>
+          <p className="growth__card-text">Watch your scores rise as you master each trait.</p>
+          <div className="growth__bars">
+            {bars.map((b) => (
+              <div key={b.id} className="growth__bar">
+                <div className="growth__bar-header">
+                  <span className="growth__bar-label">{b.label}</span>
+                  <span className="growth__bar-value">{b.value}</span>
+                </div>
+                <div className="growth__bar-track">
+                  <div className="growth__bar-fill" style={{ width: `${b.value}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="growth__actions">
+            <SecondaryButton ariaLabel="View full dashboard" onClick={onViewDashboard}>
+              View Full Dashboard
+            </SecondaryButton>
+          </div>
+        </div>
+
+        <div className="growth__content">
+          <h2 className="section-title">Your Growth Over Time</h2>
+          <p className="section-subtitle">
+            See how your Exploration score rises as you master curiosity. Every round makes your mind a little sharper.
+            Personalized missions target your weakest traits so progress always feels within reach.
+          </p>
+          <div className="growth__buttons">
+            <PrimaryButton ariaLabel="Start your journey" onClick={onStartJourney}>
+              Start Your Journey
+            </PrimaryButton>
+            <SecondaryButton ariaLabel="See example insights" onClick={onViewDashboard}>
+              See Example Insights
+            </SecondaryButton>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function WhyItMatters({ onLearnScience }) {
+  return (
+    <section className="why" aria-labelledby="why-heading">
+      <div className="section-inner why__grid">
+        <div className="why__content">
+          <h2 id="why-heading" className="section-title">
+            Why It Matters
+          </h2>
+          <p className="section-subtitle">
+            Cognify turns cognitive science into play. Every game measures real thinking patterns—exploration, logic,
+            adaptability, risk, cooperation, metacognition, and creativity—then gives you insights to grow.
+          </p>
+          <p className="section-subtitle">
+            We believe critical thinking should be as fun as any video game—and just as rewarding.
+          </p>
+          <div className="why__badge">Backed by research. Designed for growth.</div>
+        </div>
+        <div className="why__card">
+          <h3 className="why__card-title">What you’ll build</h3>
+          <ul className="why__list">
+            <li>Clarity in how you think</li>
+            <li>Confidence under uncertainty</li>
+            <li>Creative problem-solving</li>
+            <li>Strategies for cooperation</li>
+          </ul>
+          <div className="why__actions">
+            <SecondaryButton ariaLabel="Learn more science" onClick={onLearnScience}>
+              Learn the Science
+            </SecondaryButton>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ClosingCta({ onPlayNow, onLearnMore }) {
+  return (
+    <section className="cta">
+      <div className="cta__background" aria-hidden="true" />
+      <div className="section-inner cta__content">
+        <h2 className="cta__title">Start your journey to smarter thinking</h2>
+        <p className="cta__subtitle">
+          Compete with friends, track your growth, and see how far your mind can go.
         </p>
-      </div>
-
-      {/* Single Player Games */}
-      <div id="single-player" className="section solo">
-        <h2>🧩 Single Player Games</h2>
-        <div className="game-grid">
-          {games
-            .filter((g) => g.category === "solo" && g.status === "live")
-            .map((game) => (
-              <motion.div
-                key={game.id}
-                className="game-card"
-                onClick={() => navigate(game.route)}
-                style={{ borderLeft: `6px solid ${game.color}` }}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.97 }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.1, ease: "easeOut" }}
-              >
-                <h3>{game.title}</h3>
-                <p>{game.description}</p>
-              </motion.div>
-            ))}
+        <div className="cta__actions">
+          <PrimaryButton ariaLabel="Play now" onClick={onPlayNow}>
+            Play Now
+          </PrimaryButton>
+          <button aria-label="Learn more" className="cta__secondary" onClick={onLearnMore}>
+            Learn More
+          </button>
         </div>
       </div>
-
-      {/* Challenge the Computer */}
-      <div id="multiplayer" className="section vs-computer">
-        <h2>🤖 Multiplayer Games</h2>
-        <div className="game-grid vs-grid">
-          {games
-            .filter((g) => g.category === "vs-computer" && g.status === "live")
-            .map((game) => (
-              <motion.div
-                key={game.id}
-                className="game-card"
-                onClick={() => navigate(game.route)}
-                style={{ borderLeft: `6px solid ${game.color}` }}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.97 }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.1, ease: "easeOut" }}
-              >
-                <h3>{game.title}</h3>
-                <p>{game.description}</p>
-              </motion.div>
-            ))}
-        </div>
-      </div>
-
-      {/* Learn & Train */}
-      <div id="education" className="section education">
-        <h2>📚 Learn and Develop Critical Thinking Skills</h2>
-        <div className="game-grid">
-          {games
-            .filter((g) => g.category === "education" && g.status === "live")
-            .map((game) => (
-              <motion.div
-                key={game.id}
-                className="game-card"
-                onClick={() => navigate(game.route)}
-                style={{ borderLeft: `6px solid ${game.color}` }}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.97 }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.1, ease: "easeOut" }}
-              >
-                <h3>{game.title}</h3>
-                <p>{game.description}</p>
-              </motion.div>
-            ))}
-        </div>
-      </div>
-
-      {/* Thinking Insights */}
-      <div id="insights" className="section data">
-        <h2>📊 Insights</h2>
-        <div className="game-grid">
-          {games
-            .filter((g) => g.category === "data" && g.status === "live")
-            .map((game) => (
-              <motion.div
-                key={game.id}
-                className="game-card"
-                onClick={() => navigate(game.route)}
-                style={{ borderLeft: `6px solid ${game.color}` }}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.97 }}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.1, ease: "easeOut" }}
-              >
-                <h3>{game.title}</h3>
-                <p>{game.description}</p>
-              </motion.div>
-            ))}
-        </div>
-      </div>
-    </div>
+    </section>
   );
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,147 +1,564 @@
-/* Home container setup */
-.home-container {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(48px, 7vw, 72px);
-  padding: clamp(16px, 4vw, 36px);
-  color: var(--color-text-primary);
+.home-landing {
+  background-color: #ffffff;
+  color: #0f172a;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-.home-header {
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 14px;
+.section-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
 }
 
-.home-header h1 {
-  font-size: clamp(2.2rem, 5vw, 3.2rem);
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.welcome {
-  font-size: clamp(1.05rem, 2.2vw, 1.2rem);
-  color: var(--color-text-muted);
-}
-
-.subtext {
-  font-size: clamp(0.95rem, 2vw, 1.05rem);
-  color: var(--color-text-secondary);
-  max-width: 640px;
-}
-
-.section {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.section h2 {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  font-size: clamp(1.4rem, 3vw, 1.8rem);
+.section-title {
+  font-size: clamp(2rem, 3vw, 2.5rem);
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--color-text-muted);
-}
-
-.section h2::before {
-  content: "";
-  width: 36px;
-  height: 4px;
-  border-radius: 999px;
-  background: var(--gradient-accent);
-  box-shadow: 0 0 16px rgba(56, 189, 248, 0.45);
-}
-
-.game-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: clamp(20px, 4vw, 32px);
-}
-
-.game-card {
-  position: relative;
-  overflow: hidden;
-  padding: clamp(24px, 5vw, 32px);
-  border-radius: var(--radius-lg);
-  background: var(--color-surface);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: var(--glow-ambient);
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  text-align: left;
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
-  cursor: pointer;
-}
-
-.game-card::after {
-  content: "";
-  position: absolute;
-  inset: auto -40% -70% -40%;
-  height: 180px;
-  background: radial-gradient(circle, rgba(56, 189, 248, 0.35), transparent 60%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.game-card:hover {
-  transform: translateY(-6px) scale(1.01);
-  box-shadow: var(--glow-strong);
-}
-
-.game-card:hover::after {
-  opacity: 1;
-}
-
-.game-card h3 {
-  font-size: 1.3rem;
-  color: var(--color-text-primary);
+  text-align: center;
+  color: #0f172a;
   margin: 0;
 }
 
-.game-card p {
-  color: var(--color-text-secondary);
-  font-size: 0.98rem;
+.section-subtitle {
+  margin: 0.75rem auto 0;
+  max-width: 640px;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: #475569;
+  text-align: center;
+}
+
+.primary-button,
+.secondary-button,
+.cta__secondary {
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 1rem;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1.6rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+  border: none;
+}
+
+.primary-button {
+  background-color: #4f46e5;
+  color: #ffffff;
+  box-shadow: 0 15px 30px rgba(79, 70, 229, 0.2);
+}
+
+.primary-button:hover {
+  background-color: #4338ca;
+  transform: translateY(-2px);
+}
+
+.secondary-button {
+  background-color: transparent;
+  color: #1f2937;
+  border: 1px solid #cbd5f5;
+}
+
+.secondary-button:hover {
+  border-color: #818cf8;
+  color: #312e81;
+  transform: translateY(-2px);
+}
+
+.cta__secondary {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.cta__secondary:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+  transform: translateY(-2px);
+}
+
+.trait-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid #cbd5f5;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #334155;
+  background-color: #ffffff;
+  margin: 0.25rem;
+}
+
+.trait-pill--active {
+  background-color: #eef2ff;
+  border-color: #a5b4fc;
+  color: #4338ca;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 6rem 0 4rem;
+}
+
+.hero__background {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(129, 140, 248, 0.25), transparent 60%),
+    radial-gradient(circle at 80% 20%, rgba(99, 102, 241, 0.15), transparent 55%),
+    linear-gradient(180deg, #eef2ff 0%, #ffffff 80%);
+  pointer-events: none;
+}
+
+.hero__content {
+  position: relative;
+  text-align: center;
+}
+
+.hero__header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.hero__badge {
+  display: inline-flex;
+  padding: 0.4rem 1rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  background-color: rgba(224, 231, 255, 0.8);
+  color: #4338ca;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  font-weight: 800;
+  margin: 0;
+}
+
+.hero__subtitle {
+  max-width: 640px;
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: #475569;
+  margin: 0;
+}
+
+.hero__welcome {
+  font-size: 1rem;
+  color: #6366f1;
+  margin: 0;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.hero__traits {
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.how {
+  padding: 5rem 0;
+}
+
+.how__grid {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.how__card {
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.how__card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+.how__icon {
+  font-size: 2.25rem;
+}
+
+.how__title {
+  margin: 1rem 0 0.5rem;
+  font-size: 1.25rem;
+  color: #1f2937;
+}
+
+.how__description {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.traits {
+  background-color: #f8fafc;
+  padding: 5rem 0;
+}
+
+.traits__grid {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.traits__radar {
+  display: flex;
+  justify-content: center;
+}
+
+.radar {
+  max-width: 220px;
+}
+
+.traits__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.traits__tabs {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+}
+
+.traits__tab {
+  border: 1px solid #cbd5f5;
+  background-color: #ffffff;
+  color: #334155;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.traits__tab:hover {
+  border-color: #818cf8;
+  color: #312e81;
+}
+
+.traits__tab--active {
+  background-color: #4338ca;
+  color: #ffffff;
+  border-color: #4338ca;
+}
+
+.traits__card {
+  background-color: #ffffff;
+  border-radius: 1.25rem;
+  border: 1px solid #e2e8f0;
+  padding: 2rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+.traits__card-title {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #1f2937;
+}
+
+.traits__card-text {
+  margin: 1rem 0 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.traits__card-actions {
+  margin-top: 1.5rem;
+}
+
+.games {
+  padding: 5rem 0;
+}
+
+.games__grid {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.games__card {
+  background-color: #ffffff;
+  border-radius: 1.25rem;
+  border: 1px solid #e2e8f0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.games__card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+.games__visual {
+  height: 140px;
+  border-radius: 1rem;
+  border: 1px solid #c7d2fe;
+  background: linear-gradient(135deg, #eef2ff, #ffffff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.games__card-title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #1f2937;
+}
+
+.games__card-text {
+  margin: 0;
+  color: #475569;
   line-height: 1.5;
 }
 
-.game-icon {
-  font-size: 2rem;
-  color: #facc15;
+.games__traits {
+  display: flex;
+  flex-wrap: wrap;
+  margin: -0.25rem;
 }
 
-.game-grid.vs-grid {
+.games__actions {
+  margin-top: auto;
+}
+
+.growth {
+  background-color: #f8fafc;
+  padding: 5rem 0;
+}
+
+.growth__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.growth__card {
+  background-color: #ffffff;
+  border-radius: 1.5rem;
+  border: 1px solid #e2e8f0;
+  padding: 2.25rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+.growth__card-title {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #1f2937;
+}
+
+.growth__card-text {
+  margin: 0.75rem 0 0;
+  color: #475569;
+}
+
+.growth__bars {
+  margin-top: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  max-width: 760px;
-  margin: 0 auto;
+  gap: 1rem;
 }
 
-.badge-accent {
-  align-self: flex-start;
-  padding: 6px 14px;
+.growth__bar-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+.growth__bar-track {
+  margin-top: 0.5rem;
+  height: 0.5rem;
   border-radius: 999px;
-  background: rgba(56, 189, 248, 0.14);
-  color: var(--color-text-muted);
-  border: 1px solid rgba(56, 189, 248, 0.35);
-  font-size: 0.75rem;
-  letter-spacing: 0.16em;
+  background-color: #e2e8f0;
+  overflow: hidden;
 }
 
-@media (max-width: 600px) {
-  .home-container {
-    padding: 16px;
+.growth__bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #818cf8, #6366f1);
+  border-radius: 999px;
+}
+
+.growth__actions {
+  margin-top: 2rem;
+}
+
+.growth__content {
+  text-align: left;
+}
+
+.growth__buttons {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.why {
+  padding: 5rem 0;
+}
+
+.why__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.why__content .section-subtitle {
+  text-align: left;
+  margin-left: 0;
+}
+
+.why__badge {
+  display: inline-flex;
+  margin-top: 1.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background-color: rgba(99, 102, 241, 0.12);
+  color: #4338ca;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+}
+
+.why__card {
+  background: linear-gradient(145deg, #eef2ff, #ffffff);
+  border-radius: 1.5rem;
+  border: 1px solid #e2e8f0;
+  padding: 2.25rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+.why__card-title {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #1f2937;
+}
+
+.why__list {
+  margin: 1.25rem 0 0;
+  padding-left: 1.2rem;
+  color: #475569;
+  line-height: 1.7;
+}
+
+.why__actions {
+  margin-top: 1.5rem;
+}
+
+.cta {
+  position: relative;
+  overflow: hidden;
+  padding: 5rem 0;
+  margin-top: 2rem;
+}
+
+.cta__background {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #4338ca, #4f46e5);
+  pointer-events: none;
+}
+
+.cta__content {
+  position: relative;
+  text-align: center;
+  color: #ffffff;
+}
+
+.cta__title {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  font-weight: 800;
+}
+
+.cta__subtitle {
+  margin: 1rem auto 0;
+  max-width: 640px;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.cta__actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+@media (max-width: 768px) {
+  .section-inner {
+    padding: 0 1.25rem;
   }
 
-  .game-card {
-    padding: 22px;
+  .section-subtitle {
+    font-size: 1rem;
+  }
+
+  .growth__content,
+  .why__content .section-subtitle {
+    text-align: center;
+  }
+
+  .why__badge {
+    align-self: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .primary-button,
+  .secondary-button,
+  .cta__secondary {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .hero {
+    padding-top: 5rem;
+  }
+
+  .hero__title {
+    font-size: 2.25rem;
+  }
+
+  .hero__subtitle {
+    font-size: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the home page with a marketing-focused layout featuring hero, traits, games, growth, and CTA sections
- add a dedicated stylesheet that supports the new layout, button styles, and responsive tweaks

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e5cb6e29dc832c8cc7882e61b17de2