### PR TITLE
Fix global CSS imports and Firebase provider export

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,8 +1,7 @@
 /**
  * Compatibility shim for Firebase imports.
- * Uses the SSR-safe client initializer and re-exports app/auth/db for existing JS files.
- * This file intentionally stays in JS so existing pages that import it continue to work.
+ * Re-exports SSR-safe app/auth/db and googleProvider so existing pages like login.js work.
  */
-import { app, auth, db } from "./lib/firebase.client";
+import { app, auth, db, googleProvider } from "./lib/firebase.client";
 
-export { app, auth, db };
+export { app, auth, db, googleProvider };

--- a/src/lib/firebase.client.ts
+++ b/src/lib/firebase.client.ts
@@ -1,9 +1,8 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
+import { getAuth, GoogleAuthProvider } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-  // TODO: replace with your real config or env vars
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY || "demo",
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || "demo.firebaseapp.com",
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || "demo",
@@ -12,10 +11,9 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID || "1:0:web:demo"
 };
 
-// Ensure we only init on the client, and only once.
 function getFirebaseApp() {
   if (typeof window === "undefined") {
-    // Avoid initializing during SSR. Components should call from client only.
+    // Avoid initializing during SSR; consumers should guard client-only usage.
     return null as unknown as ReturnType<typeof initializeApp>;
   }
   return getApps().length ? getApp() : initializeApp(firebaseConfig);
@@ -24,3 +22,6 @@ function getFirebaseApp() {
 export const app = getFirebaseApp();
 export const auth = app ? getAuth(app) : (null as any);
 export const db   = app ? getFirestore(app) : (null as any);
+
+// Export a Google provider for login pages expecting it.
+export const googleProvider = app ? new GoogleAuthProvider() : (null as any);

--- a/src/pages/BankGame.js
+++ b/src/pages/BankGame.js
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import "../styles/bank.css";
 
 const avatarOptions = [
   "🐱",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,15 @@
+import type { AppProps } from "next/app";
+
+// Tailwind/global entry (adjust path if yours differs)
+import "../styles/globals.css";
+
+// Move page-level global CSS imports here so Next is happy.
+// Keep these even if some pages don't always need them.
+// (If a file does not exist, keep the import; Codex may create it.)
+import "../styles/bank.css";
+import "../styles/game.css";
+import "../styles/login.css";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/src/pages/game.js
+++ b/src/pages/game.js
@@ -1,5 +1,4 @@
 import { useState, useRef, useEffect } from "react";
-import "../styles/game.css";
 import stringSimilarity from "string-similarity";
 import { auth, db } from "../firebase";
 import { doc, getDoc, setDoc } from "firebase/firestore";

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -3,7 +3,6 @@ import { signInWithEmailAndPassword, signInWithPopup } from "firebase/auth";
 import { useRouter } from "next/router";
 import { doc, getDoc } from "firebase/firestore";
 import { db, auth, googleProvider } from "../firebase";
-import "../styles/login.css";
 
 function Login() {
   const [email, setEmail] = useState("");

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,4 @@
+/* globals.css – tailwind base if you use it; otherwise leave minimal */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- move all global CSS imports into Next.js custom App entrypoint
- remove direct CSS imports from individual pages
- export GoogleAuthProvider from the Firebase shim for login usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e651ce0748832c8368c54d2750bef6