### PR TITLE
Centralize global CSS imports

### DIFF
--- a/src/pages/BankGame.js
+++ b/src/pages/BankGame.js
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import "../styles/bank.css";
 
 const avatarOptions = [
   "🐱",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,14 @@
+import type { AppProps } from "next/app";
+
+// Core globals (Tailwind entry or your base CSS)
+import "../styles/globals.css";
+
+// Centralize ALL first-party global styles here:
+import "../styles/bank.css";
+import "../styles/game.css";
+import "../styles/login.css";
+import "../styles/styles.css"; // <-- this is the one causing the current error
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/src/pages/game.js
+++ b/src/pages/game.js
@@ -1,5 +1,4 @@
 import { useState, useRef, useEffect } from "react";
-import "../styles/game.css";
 import stringSimilarity from "string-similarity";
 import { auth, db } from "../firebase";
 import { doc, getDoc, setDoc } from "firebase/firestore";

--- a/src/pages/getInfo.js
+++ b/src/pages/getInfo.js
@@ -4,7 +4,6 @@ import { db } from "../firebase";
 import { doc, setDoc } from "firebase/firestore";
 import { useRouter } from "next/router";
 import { onAuthStateChanged } from "firebase/auth";
-import "../styles/styles.css";
 
 function GetInfo() {
   const [user, setUser] = useState(null);

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -3,7 +3,6 @@ import { signInWithEmailAndPassword, signInWithPopup } from "firebase/auth";
 import { useRouter } from "next/router";
 import { doc, getDoc } from "firebase/firestore";
 import { db, auth, googleProvider } from "../firebase";
-import "../styles/login.css";
 
 function Login() {
   const [email, setEmail] = useState("");

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- add a custom App component that centralizes all global stylesheet imports
- remove page-level imports of global CSS files and add a Tailwind globals entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e658089500832c9b31f5b2af08360d