### PR TITLE
Centralize global styles and export Google provider

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,8 +1,18 @@
-/**
- * Compatibility shim for Firebase imports.
- * Uses the SSR-safe client initializer and re-exports app/auth/db for existing JS files.
- * This file intentionally stays in JS so existing pages that import it continue to work.
- */
-import { app, auth, db } from "./lib/firebase.client";
+import { initializeApp, getApps, getApp } from "firebase/app";
+import { getAuth, GoogleAuthProvider } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
 
-export { app, auth, db };
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY || "demo",
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || "demo.firebaseapp.com",
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || "demo",
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "demo.appspot.com",
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || "0",
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID || "1:0:web:demo"
+};
+
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const googleProvider = new GoogleAuthProvider();
+export default app;

--- a/src/pages/BankGame.js
+++ b/src/pages/BankGame.js
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import "../styles/bank.css";
 
 const avatarOptions = [
   "🐱",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,10 @@
+import type { AppProps } from "next/app";
+import "../styles/globals.css";
+import "../styles/bank.css";
+import "../styles/game.css";
+import "../styles/login.css";
+import "../styles/styles.css";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/src/pages/game.js
+++ b/src/pages/game.js
@@ -1,5 +1,4 @@
 import { useState, useRef, useEffect } from "react";
-import "../styles/game.css";
 import stringSimilarity from "string-similarity";
 import { auth, db } from "../firebase";
 import { doc, getDoc, setDoc } from "firebase/firestore";

--- a/src/pages/getInfo.js
+++ b/src/pages/getInfo.js
@@ -4,7 +4,6 @@ import { db } from "../firebase";
 import { doc, setDoc } from "firebase/firestore";
 import { useRouter } from "next/router";
 import { onAuthStateChanged } from "firebase/auth";
-import "../styles/styles.css";
 
 function GetInfo() {
   const [user, setUser] = useState(null);

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -3,7 +3,6 @@ import { signInWithEmailAndPassword, signInWithPopup } from "firebase/auth";
 import { useRouter } from "next/router";
 import { doc, getDoc } from "firebase/firestore";
 import { db, auth, googleProvider } from "../firebase";
-import "../styles/login.css";
 
 function Login() {
   const [email, setEmail] = useState("");

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- add a custom `_app.tsx` to import shared styles from a single location
- remove per-page CSS imports now that styles load via the custom app
- replace the firebase shim with an initializer that exports `googleProvider`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e66602606c832cb8ccba399239e959