### PR TITLE
Refine mini assessment layout

### DIFF
--- a/src/pages/assess/mini.tsx
+++ b/src/pages/assess/mini.tsx
@@ -2,6 +2,8 @@ import React, { useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import { saveAssessment, type Trait, type TraitScores } from "../../lib/assess/store";
 
+import "../../styles/assessment.css";
+
 type Item = {
   id: string;
   trait: Trait;
@@ -124,36 +126,58 @@ export default function MiniAssessmentPage() {
     }
   }
 
-  if(saving){
+  if (saving) {
     return (
-      <main className="max-w-screen-md mx-auto px-4 py-12">
-        <h2 className="text-2xl font-bold">Saving your Thinking Snapshot…</h2>
-        <p className="mt-2 text-slate-600">Redirecting to home.</p>
+      <main className="assessment-shell">
+        <div className="assessment-shell__inner">
+          <section className="assessment-card assessment-card--saving" aria-live="polite">
+            <h2 className="assessment-title">Saving your Thinking Snapshot…</h2>
+            <p className="assessment-subtitle">Redirecting you back home in a moment.</p>
+          </section>
+        </div>
       </main>
     );
   }
 
   return (
-    <main className="max-w-screen-md mx-auto px-4 py-10">
-      <div aria-label="Progress" className="h-2 bg-slate-100 rounded-full overflow-hidden">
-        <div className="h-2 bg-indigo-500 transition-all" style={{ width: `${pct}%` }} />
-      </div>
-
-      <div className="mt-6 rounded-2xl border border-slate-200 p-6 shadow-sm">
-        <h2 className="text-xl font-semibold">{LABEL[item.trait]} • Question</h2>
-        <p className="mt-2 text-slate-700">{item.prompt}</p>
-        {item.note && <p className="mt-1 text-slate-500 text-sm">{item.note}</p>}
-
-        <div className="mt-5 grid gap-3">
-          {item.options.map(op=>(
-            <button key={op.id} onClick={()=>submitChoice(op.id)}
-              className="w-full text-left rounded-lg border border-slate-200 px-4 py-3 hover:bg-slate-50 transition">
-              {op.label}
-            </button>
-          ))}
+    <main className="assessment-shell">
+      <div className="assessment-shell__inner">
+        <div className="assessment-progress" aria-label="Progress">
+          <div className="assessment-progress__track">
+            <div className="assessment-progress__bar" style={{ width: `${pct}%` }} />
+          </div>
+          <span className="assessment-progress__label">{pct}% complete</span>
         </div>
 
-        {item.askConfidence && <ConfidenceCapture onPick={submitConfidence} />}
+        <section className="assessment-card" aria-labelledby="assessment-question-title">
+          <header className="assessment-card__header">
+            <span className="assessment-pill">{LABEL[item.trait]}</span>
+            <h2 id="assessment-question-title" className="assessment-title">
+              Question {i + 1} of {ITEMS.length}
+            </h2>
+          </header>
+
+          <p className="assessment-prompt">{item.prompt}</p>
+          {item.note && <p className="assessment-note">{item.note}</p>}
+
+          <div className="assessment-options" role="list">
+            {item.options.map((op, idx) => (
+              <button
+                key={op.id}
+                type="button"
+                onClick={() => submitChoice(op.id)}
+                className="assessment-option"
+              >
+                <span className="assessment-option__index" aria-hidden="true">
+                  {(idx + 10).toString(36).toUpperCase()}
+                </span>
+                <span className="assessment-option__label">{op.label}</span>
+              </button>
+            ))}
+          </div>
+
+          {item.askConfidence && <ConfidenceCapture onPick={submitConfidence} />}
+        </section>
       </div>
     </main>
   );
@@ -162,13 +186,23 @@ export default function MiniAssessmentPage() {
 function ConfidenceCapture({ onPick }: { onPick:(c:number)=>void }){
   const [val,setVal]=useState(3);
   return (
-    <div className="mt-5 rounded-lg border border-dashed border-slate-300 p-4">
-      <p className="text-sm text-slate-600">How confident are you? (1–5)</p>
-      <input type="range" min={1} max={5} value={val} onChange={e=>setVal(Number(e.target.value))} className="w-full" />
-      <div className="mt-2 flex items-center gap-3">
-        <span className="text-xs text-slate-500">Confidence: {val}/5</span>
-        <button className="ml-auto rounded-md border border-slate-300 px-3 py-1 text-sm hover:bg-slate-50"
-          onClick={()=>onPick(val)}>Submit with confidence</button>
+    <div className="assessment-confidence">
+      <p className="assessment-confidence__title">How confident are you? (1–5)</p>
+      <div className="assessment-confidence__slider">
+        <input
+          type="range"
+          min={1}
+          max={5}
+          value={val}
+          onChange={e=>setVal(Number(e.target.value))}
+          aria-label="Confidence from 1 to 5"
+        />
+      </div>
+      <div className="assessment-confidence__footer">
+        <span className="assessment-confidence__value">Confidence: {val}/5</span>
+        <button type="button" className="assessment-confidence__submit" onClick={()=>onPick(val)}>
+          Submit confidence
+        </button>
       </div>
     </div>
   );

--- a/src/styles/assessment.css
+++ b/src/styles/assessment.css
@@ -1,0 +1,270 @@
+.assessment-shell {
+  min-height: 100vh;
+  padding: clamp(2rem, 4vw, 4rem) clamp(1.5rem, 4vw, 3.5rem);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 20%, rgba(244, 114, 182, 0.08), transparent 60%),
+    linear-gradient(160deg, rgba(15, 23, 42, 0.9) 0%, rgba(2, 6, 23, 0.88) 60%, rgba(15, 23, 42, 0.95) 100%);
+}
+
+.assessment-shell__inner {
+  width: min(720px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.assessment-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.assessment-progress__track {
+  position: relative;
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.24);
+  overflow: hidden;
+}
+
+.assessment-progress__bar {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.35);
+  transition: width 260ms ease;
+}
+
+.assessment-progress__label {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.assessment-card {
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-lg);
+  padding: clamp(2rem, 3vw, 2.75rem);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: var(--glow-ambient);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.assessment-card--saving {
+  text-align: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.assessment-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.assessment-title {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 1.9rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-text-primary);
+}
+
+.assessment-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.assessment-pill {
+  align-self: flex-start;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  color: #c7d2fe;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.assessment-prompt {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-text-primary);
+}
+
+.assessment-note {
+  margin: -0.5rem 0 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.assessment-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.assessment-option {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--color-text-primary);
+  font-size: 1rem;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.assessment-option:hover,
+.assessment-option:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(99, 102, 241, 0.55);
+  background: rgba(79, 70, 229, 0.18);
+  box-shadow: 0 15px 35px rgba(79, 70, 229, 0.25);
+  outline: none;
+}
+
+.assessment-option__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 12px;
+  background: rgba(99, 102, 241, 0.18);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  font-weight: 600;
+  color: #c7d2fe;
+  flex-shrink: 0;
+}
+
+.assessment-option__label {
+  display: block;
+  line-height: 1.5;
+}
+
+.assessment-confidence {
+  margin-top: 0.5rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.assessment-confidence__title {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.01em;
+}
+
+.assessment-confidence__slider input[type="range"] {
+  width: 100%;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  outline: none;
+}
+
+.assessment-confidence__slider input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #38bdf8;
+  border: 2px solid #0ea5e9;
+  box-shadow: 0 8px 16px rgba(56, 189, 248, 0.35);
+  cursor: pointer;
+}
+
+.assessment-confidence__slider input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #38bdf8;
+  border: 2px solid #0ea5e9;
+  box-shadow: 0 8px 16px rgba(56, 189, 248, 0.35);
+  cursor: pointer;
+}
+
+.assessment-confidence__footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.assessment-confidence__value {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.assessment-confidence__submit {
+  margin-left: auto;
+  padding: 0.55rem 1.3rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.15), rgba(99, 102, 241, 0.2));
+  color: var(--color-text-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.assessment-confidence__submit:hover,
+.assessment-confidence__submit:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.28);
+  outline: none;
+}
+
+@media (max-width: 640px) {
+  .assessment-shell {
+    padding: clamp(1.5rem, 6vw, 2rem) clamp(1rem, 5vw, 1.5rem);
+  }
+
+  .assessment-card {
+    padding: clamp(1.75rem, 6vw, 2.25rem);
+  }
+
+  .assessment-option {
+    padding: 0.85rem 1rem;
+  }
+
+  .assessment-option__index {
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .assessment-progress {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .assessment-progress__label {
+    text-align: right;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the mini assessment page to align with the site's dark, glassmorphism-inspired aesthetic
- add a dedicated stylesheet for assessment components with responsive layout, option, and confidence slider treatments
- improve progress visibility and accessibility cues across the assessment experience

## Testing
- npm run lint *(fails: Next.js attempts to install @types packages via yarn and exits when the registry is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e67d4325b0832ca4bf60f19419bf1f