### PR TITLE
fix(types): allow nullish inputs to normalizeTo100 and coerce to numbers at call site

### DIFF
--- a/ccu-financial-health-app/src/app/assess/page.tsx
+++ b/ccu-financial-health-app/src/app/assess/page.tsx
@@ -1,0 +1,104 @@
+import { Metadata } from "next";
+import {
+  buildRecommendations,
+  calcEmergencyMonths,
+  calcSavingsProgress,
+  normalizeTo100,
+  scoreToBand,
+} from "@/lib/health";
+
+type AssessmentInputs = {
+  dti?: number | null;
+  monthlyExpenses?: number | null;
+  emergencyFund?: number | null;
+  creditUtilization?: number | null;
+};
+
+export const metadata: Metadata = {
+  title: "Financial Health Assessment",
+};
+
+const mockSavingsEntries: Array<{ current?: number | null; target?: number | null }> = [];
+
+function computeAssessment({
+  dti,
+  monthlyExpenses,
+  emergencyFund,
+  creditUtilization,
+}: AssessmentInputs) {
+  // ensure primitives are numbers (null -> 0)
+  const n = (v: number | null | undefined) => v ?? 0;
+  const emerg = calcEmergencyMonths({ monthlyExpenses, emergencyFund });
+  const savings = calcSavingsProgress(mockSavingsEntries); // v1 simple
+
+  const score = normalizeTo100(
+    n(dti),
+    n(emerg),
+    n(savings),
+    n(creditUtilization)
+  );
+
+  const band = scoreToBand(score);
+  const recs = buildRecommendations(
+    n(dti),
+    n(emerg),
+    n(savings),
+    n(creditUtilization)
+  );
+
+  return { score, band, recs };
+}
+
+export default function AssessPage() {
+  const { score, band, recs } = computeAssessment({
+    dti: null,
+    monthlyExpenses: null,
+    emergencyFund: null,
+    creditUtilization: null,
+  });
+
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-6 py-10">
+      <header className="space-y-2 text-center">
+        <h1 className="text-3xl font-semibold">Financial Health Assessment</h1>
+        <p className="text-slate-600">
+          This placeholder page demonstrates the normalized scoring helpers.
+        </p>
+      </header>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-medium text-slate-900">Results snapshot</h2>
+        <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="rounded-md border border-slate-100 bg-slate-50 p-4">
+            <dt className="text-sm font-medium uppercase tracking-wide text-slate-500">
+              Overall score
+            </dt>
+            <dd className="mt-1 text-2xl font-semibold text-slate-900">
+              {score.toFixed(1)} / 100
+            </dd>
+          </div>
+          <div className="rounded-md border border-slate-100 bg-slate-50 p-4">
+            <dt className="text-sm font-medium uppercase tracking-wide text-slate-500">
+              Health band
+            </dt>
+            <dd className="mt-1 text-2xl font-semibold text-slate-900">{band}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-medium text-slate-900">Recommendations</h2>
+        <ul className="space-y-2">
+          {recs.map((rec, index) => (
+            <li
+              key={index}
+              className="rounded-md border border-slate-200 bg-white p-4 shadow-sm"
+            >
+              {rec}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/ccu-financial-health-app/src/lib/health.ts
+++ b/ccu-financial-health-app/src/lib/health.ts
@@ -1,0 +1,70 @@
+// helper to clamp values
+const clamp0to100 = (n: number) => Math.max(0, Math.min(100, n));
+
+// Coerce anything nullish to 0
+const toNum = (n: number | null | undefined): number => n ?? 0;
+
+/**
+ * Normalize either a single score or multiple component scores to 0–100.
+ * - If given one value: coerce nullish to 0, then clamp to [0,100].
+ * - If given multiple values: coerce/clamp each and return their average.
+ */
+export function normalizeTo100(value: number | null | undefined): number;
+export function normalizeTo100(
+  ...values: Array<number | null | undefined>
+): number;
+export function normalizeTo100(
+  ...args: Array<number | null | undefined>
+): number {
+  if (args.length === 0) return 0;
+  if (args.length === 1) return clamp0to100(toNum(args[0]));
+
+  const sum = args
+    .map((v) => clamp0to100(toNum(v)))
+    .reduce((a, b) => a + b, 0);
+
+  return sum / args.length;
+}
+
+export function calcEmergencyMonths(args: {
+  monthlyExpenses?: number | null;
+  emergencyFund?: number | null;
+}): number {
+  const expenses = args.monthlyExpenses ?? 0;
+  const fund = args.emergencyFund ?? 0;
+  if (expenses <= 0) return 0;
+  return fund / expenses;
+}
+
+export function calcSavingsProgress(
+  _entries: Array<{ current?: number | null; target?: number | null }>
+): number {
+  // Placeholder implementation for structure completeness.
+  return 0;
+}
+
+export function scoreToBand(score: number): string {
+  if (score >= 80) return "excellent";
+  if (score >= 60) return "good";
+  if (score >= 40) return "fair";
+  return "needs-improvement";
+}
+
+export function buildRecommendations(
+  ...values: Array<number | null | undefined>
+): string[] {
+  const normalized = values.map((v) => clamp0to100(toNum(v)));
+  if (normalized.every((v) => v >= 80)) {
+    return ["Keep up the great work maintaining your financial health!"];
+  }
+
+  return normalized.map((value, index) => {
+    if (value >= 60) {
+      return `Area ${index + 1}: Solid footing—continue reinforcing these habits.`;
+    }
+    if (value >= 40) {
+      return `Area ${index + 1}: Moderate performance—consider incremental improvements.`;
+    }
+    return `Area ${index + 1}: Immediate attention recommended to strengthen this metric.`;
+  });
+}


### PR DESCRIPTION
## Summary
- update normalizeTo100 to safely handle null and undefined inputs and average multiple values
- coerce assessment inputs to numbers before computing score, band, and recommendations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1321f369c832c80103e274f76a862